### PR TITLE
Fix/input prevent redirect on enter

### DIFF
--- a/src/components/formulaire/Formulaire.tsx
+++ b/src/components/formulaire/Formulaire.tsx
@@ -1,14 +1,16 @@
 import * as lunatic from '@inseefr/lunatic';
-import { useEffect, useState } from 'react';
-
+import { useEffect, useState, useCallback } from 'react';
+import { useNavigate, useParams } from 'react-router';
 import { ComponentType } from '../../typeLunatic/type-source';
 import { OrchestratedElement } from '../../typeStromae/type';
-
+import { uriPostEnvoi, uri404 } from '../../lib/domainUri';
 import { LunaticComponentContainer } from './LunaticComponentContainer';
 
 export function Formulaire(props: OrchestratedElement) {
-	const { getComponents, currentErrors, disabled = false } = props;
+	const { getComponents, currentErrors, disabled = false, goNextPage = () => null, isLastPage } = props;
 	const [components, setComponents] = useState<Array<ComponentType>>([]);
+  const navigate = useNavigate();
+  const { unit, survey } = useParams();
 
 	useEffect(
 		() => {
@@ -19,8 +21,20 @@ export function Formulaire(props: OrchestratedElement) {
 		[getComponents]
 	);
 
+  const handleSubmit = useCallback((element: React.FormEvent<HTMLFormElement>) => {
+    element.preventDefault()
+		if (isLastPage) {
+			try {
+				navigate(uriPostEnvoi(survey, unit));
+			} catch (e) {
+				navigate(uri404());
+			}
+		}
+		goNextPage();
+	}, [goNextPage, isLastPage, unit, survey, navigate])
+
 	return (
-		<form>
+		<form onSubmit={handleSubmit}>
 			{components.map((component: ComponentType) => {
 				const { componentType, id } = component;
 				if (componentType in lunatic) {

--- a/src/components/formulaire/Formulaire.tsx
+++ b/src/components/formulaire/Formulaire.tsx
@@ -1,16 +1,12 @@
 import * as lunatic from '@inseefr/lunatic';
-import { useEffect, useState, useCallback } from 'react';
-import { useNavigate, useParams } from 'react-router';
+import { useEffect, useState } from 'react';
 import { ComponentType } from '../../typeLunatic/type-source';
 import { OrchestratedElement } from '../../typeStromae/type';
-import { uriPostEnvoi, uri404 } from '../../lib/domainUri';
 import { LunaticComponentContainer } from './LunaticComponentContainer';
 
 export function Formulaire(props: OrchestratedElement) {
-	const { getComponents, currentErrors, disabled = false, goNextPage = () => null, isLastPage } = props;
+	const { getComponents, currentErrors, disabled = false } = props;
 	const [components, setComponents] = useState<Array<ComponentType>>([]);
-  const navigate = useNavigate();
-  const { unit, survey } = useParams();
 
 	useEffect(
 		() => {
@@ -21,20 +17,10 @@ export function Formulaire(props: OrchestratedElement) {
 		[getComponents]
 	);
 
-  const handleSubmit = useCallback((element: React.FormEvent<HTMLFormElement>) => {
-    element.preventDefault()
-		if (isLastPage) {
-			try {
-				navigate(uriPostEnvoi(survey, unit));
-			} catch (e) {
-				navigate(uri404());
-			}
-		}
-		goNextPage();
-	}, [goNextPage, isLastPage, unit, survey, navigate])
-
 	return (
-		<form onSubmit={handleSubmit}>
+		<form 
+      id="stromae-form" 
+    >
 			{components.map((component: ComponentType) => {
 				const { componentType, id } = component;
 				if (componentType in lunatic) {

--- a/src/components/navigation/Continuer.tsx
+++ b/src/components/navigation/Continuer.tsx
@@ -38,7 +38,8 @@ export function Continuer(props: OrchestratedElement) {
 	const { unit, survey } = useParams();
 	const buttonContent = getStatus(getComponents, isLastPage ?? false);
 
-	const handleClick = useCallback(() => {
+	const handleClick = useCallback((event: React.MouseEvent) => {
+      event.preventDefault()
 		if (isLastPage) {
 			try {
 				navigate(uriPostEnvoi(survey, unit));
@@ -54,6 +55,7 @@ export function Continuer(props: OrchestratedElement) {
 			priority="primary"
 			onClick={handleClick}
 			className={fr.cx('fr-mt-1w')}
+      nativeButtonProps={{"form": "stromae-form", "type": "submit"}}
 		>
 			{buttonContent}
 		</Button>


### PR DESCRIPTION
We had a bug where if a user hit enter while focused on an input on a page with only one input, the navigator would refresh. 
We determined that this was due to the default `onSubmit` being called, and decided to force the behaviour of the `handleClick` in the `<Continuer />` component. (see [here](https://www.tjvantoll.com/2013/01/01/enter-should-submit-forms-stop-messing-with-that/) for more information on submission of forms)