### PR TITLE
V3 update continue button on load

### DIFF
--- a/src/components/navigation/Continuer.tsx
+++ b/src/components/navigation/Continuer.tsx
@@ -33,13 +33,14 @@ export function Continuer(props: OrchestratedElement) {
 		goNextPage = () => null,
 		isLastPage,
 		getComponents = () => [],
+    waiting = false
 	} = props;
 	const navigate = useNavigate();
 	const { unit, survey } = useParams();
-	const buttonContent = getStatus(getComponents, isLastPage ?? false);
+	const buttonContent = waiting ? `Chargement` : getStatus(getComponents, isLastPage ?? false);
 
 	const handleClick = useCallback((event: React.MouseEvent) => {
-      event.preventDefault()
+    event.preventDefault()
 		if (isLastPage) {
 			try {
 				navigate(uriPostEnvoi(survey, unit));
@@ -55,9 +56,12 @@ export function Continuer(props: OrchestratedElement) {
 			priority="primary"
 			onClick={handleClick}
 			className={fr.cx('fr-mt-1w')}
-      nativeButtonProps={{"form": "stromae-form", "type": "submit"}}
+      nativeButtonProps={{"form": "stromae-form", "type": "submit", "aria-atomic": true, "aria-disabled": waiting}}
+      iconId={waiting ? "fr-icon-refresh-line" : undefined}
+      disabled={waiting}
 		>
 			{buttonContent}
 		</Button>
 	);
 }
+

--- a/src/components/orchestrator/Saving/SaveOnPage.tsx
+++ b/src/components/orchestrator/Saving/SaveOnPage.tsx
@@ -15,12 +15,14 @@ export function SaveOnPage(props: PropsWithChildren<OrchestratedElement>) {
 
 	const [savingFailure, setSavingFailure] = useState<SavingFailure>();
 	const save = useSaving({ currentChange, getData, pageTag, isLastPage });
+  const [ waiting, setWaiting ] = useState(false); 
 
 	const handleNextPage = useCallback(async () => {
 		try {
 			setSavingFailure(undefined);
+      setWaiting(true);
 			const somethingToSave = await save();
-
+      setWaiting(false);
 			if (somethingToSave) {
 				setSavingFailure({ status: 200 });
 			}
@@ -35,6 +37,7 @@ export function SaveOnPage(props: PropsWithChildren<OrchestratedElement>) {
 			{...rest}
 			goNextPage={handleNextPage}
 			savingFailure={savingFailure}
+      waiting={waiting}
 		>
 			{children}
 		</CloneElements>

--- a/src/typeStromae/type.ts
+++ b/src/typeStromae/type.ts
@@ -61,6 +61,7 @@ export type OrchestratedElement = {
 	currentChange?: { name: string };
 	// saving
 	savingFailure?: SavingFailure;
+  waiting?: boolean; 
 	// disabled all components
 	disabled?: boolean;
 	currentPage?: string;


### PR DESCRIPTION
I implemented a `waiting` flag on the `SaveOnPage` function to indicate that the continue button has been clicked/form has been submitted, and that the application is loading.  
The button is disabled if this flag is true. 
The `"aria-atomic": true, "aria-disabled": waiting` props indicate to screen-reader users that the button is unavailable. 