### PR TITLE
upper case preffered_user in Portail

### DIFF
--- a/src/pages/portail/Portail.tsx
+++ b/src/pages/portail/Portail.tsx
@@ -20,7 +20,7 @@ export function Portail() {
 			return;
 		}
 		navigate(
-			`/questionnaire/${survey}/unite-enquetee/${oidcUser.preferred_username}`
+			`/questionnaire/${survey}/unite-enquetee/${oidcUser.preferred_username.toUpperCase()}`
 		);
 	}, [oidcUser, navigate, survey]);
 


### PR DESCRIPTION
Preferred user name est tourjours en minuscule dans le jeton et il doit être livré en majuscule.
Cette modification ne concerne que la page portail et n'affecte pas la filière d'enquête.