### PR TITLE
fix roundabout controls 

### DIFF
--- a/src/components/formulaire/Formulaire.tsx
+++ b/src/components/formulaire/Formulaire.tsx
@@ -5,7 +5,7 @@ import { OrchestratedElement } from '../../typeStromae/type';
 import { LunaticComponentContainer } from './LunaticComponentContainer';
 
 export function Formulaire(props: OrchestratedElement) {
-	const { getComponents, currentErrors, disabled = false } = props;
+	const { getComponents, currentErrors, disabled = false, handleGoIteration } = props;
 	const [components, setComponents] = useState<Array<ComponentType>>([]);
 
 	useEffect(() => {
@@ -15,8 +15,8 @@ export function Formulaire(props: OrchestratedElement) {
 	}, [getComponents]);
 
 	return (
-		<form 
-      id="stromae-form" 
+		<form
+      id="stromae-form"
     >
 			{components.map((component: ComponentType) => {
 				const { componentType, id } = component;
@@ -30,6 +30,7 @@ export function Formulaire(props: OrchestratedElement) {
 								{...component}
 								errors={currentErrors}
 								disabled={disabled}
+								handleGoIteration={handleGoIteration}
 							/>
 						</LunaticComponentContainer>
 					);

--- a/src/components/orchestrator/Controls.tsx
+++ b/src/components/orchestrator/Controls.tsx
@@ -39,9 +39,16 @@ export function Controls(props: PropsWithChildren<OrchestratedElement>) {
 		}
 	}, [compileControls, goNextPage, warning]);
 
+	const handleGoIteration = useCallback(() => {
+		setWarning(false);
+		setCurrentErrors(undefined);
+		setCriticality(false);
+	}, [])
+
 	const handleGoPrevious: () => void = useCallback(() => {
 		setCriticality(undefined);
 		setCurrentErrors(undefined);
+		setWarning(false);
 		goPreviousPage();
 	}, [goPreviousPage]);
 
@@ -52,6 +59,7 @@ export function Controls(props: PropsWithChildren<OrchestratedElement>) {
 			goPreviousPage={handleGoPrevious}
 			criticality={criticality}
 			currentErrors={currentErrors}
+			handleGoIteration={handleGoIteration}
 		>
 			{children}
 		</CloneElements>

--- a/src/typeStromae/type.ts
+++ b/src/typeStromae/type.ts
@@ -39,6 +39,7 @@ export type OrchestratedElement = {
 	readonly goPreviousPage?: () => void;
 	readonly goNextPage?: (arg?: { block: boolean }) => void;
 	readonly goToPage?: (page: { page: string; iteration?: number }) => void;
+	readonly handleGoIteration?: () => void;
 	readonly getErrors?: () => Record<
 		string,
 		Record<string, Array<LunaticError>>
@@ -61,7 +62,7 @@ export type OrchestratedElement = {
 	currentChange?: { name: string };
 	// saving
 	savingFailure?: SavingFailure;
-  waiting?: boolean; 
+	waiting?: boolean;
 	// disabled all components
 	disabled?: boolean;
 	currentPage?: string;


### PR DESCRIPTION
There are two bugs in the Roundabout when using Lunatic-DSFR: 
- When an error appears on the roundabout page, if they click through to an iteration, the error persits, but it should disappear. (Bug 1) 
- After following above step, if user returns to roundabout page, the error does not display, but if they click continue, the error does not display and the user is allowed to continue.  The error should display again and block the user. (Bug 2) 

**Fix: **
- Stromae creates a function `handleGoIteration` that sets the errors to `undefined`.  This function is passed with cloneElement to children, and then is accessible to all components.  In Lunatic, the Roundabout component charges the goToIteration with the handleGoIteration function to reset the errors when entering an iteration. 
- When clicking back, stromae sets `warning` to false, that way upon clicking continue, the alert appears again. 