### PR TITLE
add useEffect to remove errors when entering roundabout iteration

### DIFF
--- a/src/components/AlertesControles/AlertesControles.tsx
+++ b/src/components/AlertesControles/AlertesControles.tsx
@@ -15,7 +15,7 @@ function ErrorMessage({errorMessage}: {errorMessage: ReactNode}) {
 }
 
 export function AlertesControles(props: OrchestratedElement) {
-	const { currentErrors, criticality } = props;
+	const { currentErrors, criticality, pageTag } = props;
 	const type = criticality ? 'fr-alert--error' : 'fr-alert--warning';
 
 	useEffect(() => {
@@ -24,7 +24,7 @@ export function AlertesControles(props: OrchestratedElement) {
 		}
 	}, [currentErrors]);
 
-	if (currentErrors) {
+	if (currentErrors && !(currentErrors.roundabout && pageTag?.includes("#"))) {
 		const content = Object.values(currentErrors)
 			.flat()
 			.map(({ errorMessage, id }) => {

--- a/src/components/AlertesControles/AlertesControles.tsx
+++ b/src/components/AlertesControles/AlertesControles.tsx
@@ -15,7 +15,7 @@ function ErrorMessage({errorMessage}: {errorMessage: ReactNode}) {
 }
 
 export function AlertesControles(props: OrchestratedElement) {
-	const { currentErrors, criticality, pageTag } = props;
+	const { currentErrors, criticality } = props;
 	const type = criticality ? 'fr-alert--error' : 'fr-alert--warning';
 
 	useEffect(() => {
@@ -24,7 +24,7 @@ export function AlertesControles(props: OrchestratedElement) {
 		}
 	}, [currentErrors]);
 
-	if (currentErrors && !(currentErrors.roundabout && pageTag?.includes("#"))) {
+	if (currentErrors) {
 		const content = Object.values(currentErrors)
 			.flat()
 			.map(({ errorMessage, id }) => {

--- a/src/components/orchestrator/Controls.tsx
+++ b/src/components/orchestrator/Controls.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, useCallback, useState } from 'react';
+import { PropsWithChildren, useCallback, useEffect, useState } from 'react';
 
 import { LunaticError } from '../../typeLunatic/type';
 import { OrchestratedElement } from '../../typeStromae/type';
@@ -16,17 +16,31 @@ export function Controls(props: PropsWithChildren<OrchestratedElement>) {
 		goNextPage = () => null,
 		goPreviousPage = () => null,
 		compileControls,
+		pageTag,
 		...rest
 	} = props;
 
+	useEffect(() => {
+		if (!(currentErrors?.roundabout && pageTag?.includes("#"))) {
+			return;
+		} 
+		setWarning(false)
+		setCurrentErrors(undefined);
+		setCriticality(false);
+	}, [pageTag, currentErrors]);
+
 	const handleGoNext = useCallback(() => {
+		let errors;
+		if (compileControls) {
+			errors = compileControls();
+		}
+
 		if (warning) {
 			setWarning(false);
 			setCurrentErrors(undefined);
 			setCriticality(false);
 			goNextPage();
-		} else if (compileControls) {
-			const errors = compileControls();
+		} else if (errors) {
 			setCriticality(errors.isCritical);
 			setCurrentErrors(errors.currentErrors);
 			if (errors.currentErrors && !errors.isCritical) {
@@ -40,6 +54,7 @@ export function Controls(props: PropsWithChildren<OrchestratedElement>) {
 	}, [compileControls, goNextPage, warning]);
 
 	const handleGoPrevious: () => void = useCallback(() => {
+		setWarning(false)
 		setCriticality(undefined);
 		setCurrentErrors(undefined);
 		goPreviousPage();


### PR DESCRIPTION
Solution replaces [Stromae 330](https://github.com/InseeFr/Stromae/pull/330) and [Lunatic 589](https://github.com/InseeFr/Lunatic/pull/589).

There are two bugs in the Roundabout when using Lunatic-DSFR:

- When an error appears on the roundabout page, if they click through to an iteration, the error persits, but it should disappear. (Bug 1)
- After following above step, if user returns to roundabout page, the error does not display, but if they click continue, the error does not display and the user is allowed to continue. The error should display again and block the user. (Bug 2)

**Fix:**

- Stromae listens to `currentErrors` and `pageTag`, and if there is an error `currentErrors.roundabout` and if `pageTag` includes a `"#"` (meaning that we have incited an error and entered into an iteration) then Stromae will set the errors to undefined and the warning to false.  Note: it is important to set the warning to false so that the error on page `n.1#i` is executed on continue
- When clicking back, stromae sets warning to false, that way upon clicking continue, the alert appears again.

![image](https://github.com/InseeFr/Stromae/assets/87824367/1d786ebc-3521-44d6-a568-3d877ff5cafb)
Error appears, click goToIteration
![image](https://github.com/InseeFr/Stromae/assets/87824367/9b12abe9-21fb-4dc0-af98-8b732177bdd6)
Error persists (Bug 1), click back
![image](https://github.com/InseeFr/Stromae/assets/87824367/07ccdab0-0b30-4793-9ebb-ab1246dd3e22)
Error no longer displayed, click continue
![image](https://github.com/InseeFr/Stromae/assets/87824367/df70a3f0-2683-4f73-b2a8-c7edd6face77)
User allowed to continue, although error should appear (Bug 2) 
![image](https://github.com/InseeFr/Stromae/assets/87824367/518e318b-644b-4d7d-a8be-7a62e3d32099)





