### PR TITLE
Fix/v3 save on next page

### DIFF
--- a/src/components/ContinueOrRestart/ContinueOrRestart.tsx
+++ b/src/components/ContinueOrRestart/ContinueOrRestart.tsx
@@ -3,20 +3,20 @@ import { OrchestratedElement } from '../../typeStromae/type';
 import { ModalContinueOrRestart } from './ModalContinueOrRestart';
 
 export function ContinueOrRestart(props: OrchestratedElement) {
-	const { currentPage, goToPage } = props;
-	const [display, setDisplay] = useState(currentPage && currentPage !== '1');
+	const { pageFromAPI, goToPage } = props;
+	const [display, setDisplay] = useState(pageFromAPI && pageFromAPI !== '1');
 
 	function onClose() {
 		setDisplay(false);
 	}
 
 	const onContinue = useCallback(() => {
-		if (!currentPage) {
+		if (!pageFromAPI) {
 			return;
 		}
-		goToPage?.({ page: currentPage });
+		goToPage?.({ page: pageFromAPI });
 		setDisplay(false);
-	}, [currentPage, goToPage]);
+	}, [pageFromAPI, goToPage]);
 
 	const onRestart = useCallback(() => {
 		goToPage?.({ page: '1' });

--- a/src/components/navigation/Continuer.tsx
+++ b/src/components/navigation/Continuer.tsx
@@ -58,15 +58,22 @@ export function Continuer(props: OrchestratedElement) {
 	);
 
 	return (
-		<Button
-			priority="primary"
-			onClick={handleClick}
-			className={fr.cx('fr-mt-1w')}
-			nativeButtonProps={{ "form": "stromae-form", "type": "submit", "aria-atomic": true, "aria-disabled": waiting }}
-			iconId={waiting ? "fr-icon-refresh-line" : undefined}
-			disabled={waiting}
-		>
-			{buttonContent}
-		</Button>
+		<>
+			<Button
+				priority="primary"
+				onClick={handleClick}
+				className={fr.cx('fr-mt-1w')}
+				nativeButtonProps={{
+					form: 'stromae-form',
+					type: 'submit',
+					'aria-atomic': true,
+					'aria-disabled': waiting,
+				}}
+				iconId={waiting ? 'fr-icon-refresh-line' : undefined}
+				disabled={waiting}
+			>
+				{buttonContent}
+			</Button>
+		</>
 	);
 }

--- a/src/components/orchestrator/Saving/SaveOnPage.tsx
+++ b/src/components/orchestrator/Saving/SaveOnPage.tsx
@@ -6,7 +6,6 @@ import { usePrevious } from '../../../lib/commons/usePrevious';
 import { useAsyncEffect } from '../../../hooks/useAsyncEffect';
 
 export function SaveOnPage(props: PropsWithChildren<OrchestratedElement>) {
-	const { children, ...rest } = props;
 	const {
 		goNextPage,
 		goPreviousPage,
@@ -15,7 +14,8 @@ export function SaveOnPage(props: PropsWithChildren<OrchestratedElement>) {
 		getData,
 		isLastPage,
 		collectStatus,
-	} = rest;
+		children,
+	} = props;
 
 	const previousPage = usePrevious(currentPage);
 	const [savingFailure, setSavingFailure] = useState<SavingFailure>();
@@ -28,14 +28,11 @@ export function SaveOnPage(props: PropsWithChildren<OrchestratedElement>) {
 	});
 	const [waiting, setWaiting] = useState(false);
 	const shouldSync = useRef(false);
+	// eslint-disable-next-line @shopify/binary-assignment-parens
+	const isNewPage = currentPage && previousPage && previousPage !== currentPage;
 
 	useAsyncEffect(async () => {
-		if (
-			currentPage &&
-			previousPage &&
-			shouldSync.current &&
-			previousPage !== currentPage
-		) {
+		if (isNewPage) {
 			shouldSync.current = false;
 			try {
 				setSavingFailure(undefined);
@@ -49,7 +46,7 @@ export function SaveOnPage(props: PropsWithChildren<OrchestratedElement>) {
 				setSavingFailure({ status: 500 });
 			}
 		}
-	}, [shouldSync, currentPage, previousPage, save]);
+	}, [isNewPage, save]);
 
 	const handleNextPage = useCallback(async () => {
 		if (currentPage) {
@@ -65,7 +62,7 @@ export function SaveOnPage(props: PropsWithChildren<OrchestratedElement>) {
 
 	return (
 		<CloneElements<OrchestratedElement>
-			{...rest}
+			{...props}
 			goNextPage={handleNextPage}
 			goPreviousPage={handleGoBack}
 			savingFailure={savingFailure}

--- a/src/components/orchestrator/Saving/SaveOnPage.tsx
+++ b/src/components/orchestrator/Saving/SaveOnPage.tsx
@@ -18,13 +18,13 @@ export function SaveOnPage(props: PropsWithChildren<OrchestratedElement>) {
 		currentChange,
 		currentPage,
 		getData,
-		pageTag,
+
 		isLastPage,
 	} = rest;
 	const previousPage = usePrevious(currentPage);
 
 	const [savingFailure, setSavingFailure] = useState<SavingFailure>();
-	const save = useSaving({ currentChange, getData, pageTag, isLastPage });
+	const save = useSaving({ currentChange, getData, currentPage, isLastPage });
 	const [waiting, setWaiting] = useState(false);
 	const onSave = useRef(false);
 

--- a/src/components/orchestrator/Saving/SaveOnSequence.tsx
+++ b/src/components/orchestrator/Saving/SaveOnSequence.tsx
@@ -1,9 +1,7 @@
 import { PropsWithChildren, useState, useCallback } from 'react';
-
 import { CloneElements } from '../CloneElements';
 import { isComponentsContainSequence } from '../../../lib/commons/isComponentscontainSequence';
 import { OrchestratedElement, SavingFailure } from '../../../typeStromae/type';
-
 import { useSaving } from './useSaving';
 
 export function SaveOnSequence(props: PropsWithChildren<OrchestratedElement>) {

--- a/src/components/orchestrator/Saving/useSaving.ts
+++ b/src/components/orchestrator/Saving/useSaving.ts
@@ -6,11 +6,11 @@ const SAVING_STRATEGY = process.env.REACT_APP_SAVING_STRATEGY;
 
 type SavingArgs = Pick<
 	OrchestratedElement,
-	'currentChange' | 'getData' | 'pageTag' | 'isLastPage'
+	'currentChange' | 'getData' | 'currentPage' | 'isLastPage'
 >;
 
 export function useSaving(args: SavingArgs) {
-	const { currentChange, getData, pageTag, isLastPage } = args;
+	const { currentChange, getData, currentPage, isLastPage } = args;
 	const changes = useRef<Record<string, null>>({});
 	const { putSurveyUnitData } = useContext(loadSourceDataContext);
 
@@ -50,7 +50,7 @@ export function useSaving(args: SavingArgs) {
 			const state = {
 				state: 'INIT',
 				date: new Date().getTime(),
-				currentPage: pageTag ?? '1',
+				currentPage: currentPage ?? '1',
 			};
 			const status = await putSurveyUnitData({ data, state });
 			if (status) {

--- a/src/components/orchestrator/UseLunatic.tsx
+++ b/src/components/orchestrator/UseLunatic.tsx
@@ -46,10 +46,6 @@ export function UseLunatic(props: PropsWithChildren<OrchestratorProps>) {
 		setCurrentChange({ name });
 	}, []);
 
-	const [currentPage, setCurrentPage] = useState(() => {
-		return pageFromAPI ?? '1';
-	});
-
 	useEffect(() => {
 		setPersonalizationMap(createPersonalizationMap(personalization));
 	}, [personalization]);
@@ -96,10 +92,8 @@ export function UseLunatic(props: PropsWithChildren<OrchestratorProps>) {
 			typeof defaultTitle === 'string' ? defaultTitle : 'Enquête Insee',
 	});
 
-	useEffect(() => {
-		const { page } = pager;
-		setCurrentPage(page);
-	}, [pager]);
+	const currentPage = pager.page;
+
 	const collectStatus = state ?? CollectStatusEnum.Init;
 	useRedirectIfAlreadyValidated(collectStatus);
 

--- a/src/components/orchestrator/UseLunatic.tsx
+++ b/src/components/orchestrator/UseLunatic.tsx
@@ -35,17 +35,17 @@ export function UseLunatic(props: PropsWithChildren<OrchestratorProps>) {
 	const [personalizationMap, setPersonalizationMap] = useState<
 		Record<string, string>
 	>({});
-	const {
-		data,
-		stateData = { currentPage: '1' },
-		personalization = [],
-	} = surveyUnitData ?? {};
-	const { currentPage } = stateData;
+	const { data, stateData, personalization = [] } = surveyUnitData ?? {};
+	const { currentPage: pageFromAPI } = stateData ?? {};
 	const [currentChange, setCurrentChange] = useState<{ name: string }>();
 
 	const onChange = useCallback(({ name }: { name: string }, value: unknown) => {
 		setCurrentChange({ name });
 	}, []);
+
+	const [currentPage, setCurrentPage] = useState(() => {
+		return pageFromAPI ?? '1';
+	});
 
 	useEffect(() => {
 		setPersonalizationMap(createPersonalizationMap(personalization));
@@ -86,7 +86,17 @@ export function UseLunatic(props: PropsWithChildren<OrchestratorProps>) {
 	} = useLunatic(source, data, args);
 
 	const defaultTitle = metadata?.Header?.serviceTitle;
-	useQuestionnaireTitle({ source, page: pager.page, defaultTitle: typeof defaultTitle === 'string' ? defaultTitle : 'Enquête Insee'  });
+	useQuestionnaireTitle({
+		source,
+		page: pager.page,
+		defaultTitle:
+			typeof defaultTitle === 'string' ? defaultTitle : 'Enquête Insee',
+	});
+
+	useEffect(() => {
+		const { page } = pager;
+		setCurrentPage(page);
+	}, [pager, currentPage]);
 
 	return (
 		<Provider>
@@ -103,6 +113,7 @@ export function UseLunatic(props: PropsWithChildren<OrchestratorProps>) {
 				pageTag={pageTag}
 				disabled={disabled}
 				currentPage={currentPage}
+				pageFromAPI={pageFromAPI}
 				personalization={personalizationMap}
 			>
 				{children}

--- a/src/components/orchestrator/UseLunatic.tsx
+++ b/src/components/orchestrator/UseLunatic.tsx
@@ -99,7 +99,7 @@ export function UseLunatic(props: PropsWithChildren<OrchestratorProps>) {
 	useEffect(() => {
 		const { page } = pager;
 		setCurrentPage(page);
-	}, [pager, currentPage]);
+	}, [pager]);
 	const collectStatus = state ?? CollectStatusEnum.Init;
 	useRedirectIfAlreadyValidated(collectStatus);
 

--- a/src/typeStromae/type.ts
+++ b/src/typeStromae/type.ts
@@ -74,6 +74,8 @@ export type OrchestratedElement = {
 	// disabled all components
 	disabled?: boolean;
 	currentPage?: string;
+	// Page give by API.getSuData at launch
+	pageFromAPI?: string;
 	only?: string[];
 	except?: string[];
 	title?: string;

--- a/src/typeStromae/type.ts
+++ b/src/typeStromae/type.ts
@@ -81,7 +81,7 @@ export type OrchestratedElement = {
 	disabled?: boolean;
 	// last page reach by user
 	currentPage?: string;
-	// Page give by API.getSuData at launch
+	// Page given by API.getSuData at launch
 	pageFromAPI?: string;
 	// last status of survey, give by the API ('INIT' | 'COLLECTED' | 'VALIDATED')
 	collectStatus?: CollectStatusEnum;


### PR DESCRIPTION
Jusqu'alors, currentPage, sauvegardé par l'API contenait la page sur laquelle on étatit lorsque l'on cliquait sur le bouton continuer ou précédent. Désormais, currentPage contient la page sur laquelle on arrive après avoir pressé un bouton de navigation.
- currentPage transmis au démarrage par getStateData est transmis dans à la modal ContinueOrRestart dans pageFromAPI
- currentPage contient maintenant la valeur pager.page, transmis à l'API 
- on ne fait appel à save, que si currentPage change et si l'utilisateur à presser un bouton de navigation. La Double condition permet d'éviter  des sauvegardes redondantes.
