### PR TITLE
remove token and let axa do the job

### DIFF
--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -6,7 +6,7 @@ import {
 } from '@axa-fr/react-oidc';
 
 import { Layout as LayoutSkeleton } from '../skeleton/Layout';
-import { publicGetRequest } from '../../lib/commons/axios-utils';
+import { getRequest } from '../../lib/commons/axios-utils';
 import { useAsyncEffect } from '../../hooks/useAsyncEffect';
 
 function Pending() {
@@ -18,7 +18,7 @@ type AuthProviderProps = {
 };
 
 function fetchConfig(): Promise<OidcConfiguration> {
-	return publicGetRequest<OidcConfiguration>('/configuration.json');
+	return getRequest<OidcConfiguration>('/configuration.json');
 }
 
 export function AuthProvider({ children }: AuthProviderProps) {

--- a/src/components/loadSourceData/LoadFromApi.tsx
+++ b/src/components/loadSourceData/LoadFromApi.tsx
@@ -1,5 +1,4 @@
 import { PropsWithChildren, useCallback } from 'react';
-import { useOidcAccessToken } from '../../lib/oidc';
 import { surveyApi } from '../../lib/surveys/surveysApi';
 import { DataVariables, StateData } from '../../typeStromae/type';
 
@@ -15,8 +14,6 @@ export function LoadFromApi({
 	unit,
 	children,
 }: PropsWithChildren<LoadFromApiProps>) {
-	const { accessToken } = useOidcAccessToken();
-
 	const getMetadata = useCallback(async () => {
 		if (survey) {
 			return surveyApi.getMetadataSurvey(survey);
@@ -25,38 +22,32 @@ export function LoadFromApi({
 	}, [survey]);
 
 	const getSurvey = useCallback(async () => {
-		if (survey && accessToken) {
-			return surveyApi.getSurvey(survey, accessToken);
+		if (survey) {
+			return surveyApi.getSurvey(survey);
 		}
 		return undefined;
-	}, [survey, accessToken]);
+	}, [survey]);
 
 	const getSurveyUnitData = useCallback(async () => {
-		if (accessToken && unit) {
-			return surveyApi.getSurveyUnitData(unit, accessToken);
+		if (unit) {
+			return surveyApi.getSurveyUnitData(unit);
 		}
 		return undefined;
-	}, [unit, accessToken]);
+	}, [unit]);
 
-	const getReferentiel = useCallback(
-		async (name: string) => {
-			return surveyApi.getNomenclature(name, accessToken);
-		},
-		[accessToken]
-	);
+	const getReferentiel = useCallback(async (name: string) => {
+		return surveyApi.getNomenclature(name);
+	}, []);
 
-	const getDepositProof = useCallback(
-		async (unit: string) => {
-			return surveyApi.getDepositiProof(unit, accessToken);
-		},
-		[accessToken]
-	);
+	const getDepositProof = useCallback(async (unit: string) => {
+		return surveyApi.getDepositiProof(unit);
+	}, []);
 
 	const putSurveyUnitStateData = useCallback(
 		async (state?: StateData) => {
 			try {
 				if (state && unit) {
-					await surveyApi.putSurveyUnitStateData(state, unit, accessToken);
+					await surveyApi.putSurveyUnitStateData(state, unit);
 				}
 			} catch (e) {
 				// eslint-disable-next-line no-console
@@ -65,7 +56,7 @@ export function LoadFromApi({
 			}
 			return true;
 		},
-		[accessToken, unit]
+		[unit]
 	);
 
 	const putSurveyUnitData = useCallback(
@@ -73,7 +64,7 @@ export function LoadFromApi({
 			try {
 				if (data) {
 					if (unit) {
-						await surveyApi.putSurveyUnitData(data, unit, accessToken);
+						await surveyApi.putSurveyUnitData(data, unit);
 					}
 				}
 			} catch (e) {
@@ -83,7 +74,7 @@ export function LoadFromApi({
 			}
 			return true;
 		},
-		[accessToken, unit]
+		[unit]
 	);
 
 	return (

--- a/src/components/loadSourceData/LoadFromUrl.tsx
+++ b/src/components/loadSourceData/LoadFromUrl.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren, useCallback } from 'react';
 import type { LunaticSource } from '../../typeLunatic/type-source';
-import { publicGetRequest } from '../../lib/commons/axios-utils';
+import { getRequest } from '../../lib/commons/axios-utils';
 import { SurveyUnitData, MetadataSurvey } from '../../typeStromae/type';
 import { loadSourceDataContext } from './LoadSourceDataContext';
 
@@ -31,19 +31,19 @@ export function LoadFromUrl({
 }: PropsWithChildren<LoadFromUrlProps>) {
 	const getMetadata = useCallback(async () => {
 		if (urlMetadata) {
-			return publicGetRequest<MetadataSurvey>(urlMetadata);
+			return getRequest<MetadataSurvey>(urlMetadata);
 		}
 		return undefined;
 	}, [urlMetadata]);
 	const getSurvey = useCallback(async () => {
 		if (urlSource) {
-			return publicGetRequest<LunaticSource>(urlSource);
+			return getRequest<LunaticSource>(urlSource);
 		}
 		return undefined;
 	}, [urlSource]);
 	const getSurveyUnitData = useCallback(async () => {
 		if (urlData) {
-			return publicGetRequest<SurveyUnitData>(urlData);
+			return getRequest<SurveyUnitData>(urlData);
 		}
 		return undefined;
 	}, [urlData]);
@@ -52,7 +52,7 @@ export function LoadFromUrl({
 		async (name: string): Promise<Array<unknown>> => {
 			if (name in urlNomenclatures) {
 				const url = urlNomenclatures[name];
-				return publicGetRequest<Array<unknown>>(url);
+				return getRequest<Array<unknown>>(url);
 			}
 
 			return [];

--- a/src/lib/commons/axios-utils.ts
+++ b/src/lib/commons/axios-utils.ts
@@ -30,18 +30,11 @@ function errorHandler(error: AxiosError) {
 	}
 }
 
-function jwtHeaders(token: string, contentType?: string) {
-	return {
-		Authorization: `Bearer ${token}`,
-		'Content-type': contentType ?? 'application/json; charset=utf-8',
-	};
-}
-
 function publicHeader() {
 	return { 'Content-type': 'application/json; charset=utf-8' };
 }
 
-export async function publicGetRequest<T>(url: string) {
+export async function getRequest<T>(url: string) {
 	try {
 		const headers = publicHeader();
 		const { data } = await axios<T>({ method: HTTP_VERBS.get, url, headers });
@@ -52,28 +45,9 @@ export async function publicGetRequest<T>(url: string) {
 	}
 }
 
-export async function authenticatedGetRequest<T>(
-	url: string,
-	token: string,
-	contentType?: string
-) {
+export async function getBlob(url: string) {
 	try {
-		const headers = jwtHeaders(token, contentType);
-		const { data } = await axios<T>({
-			method: HTTP_VERBS.get,
-			url,
-			headers,
-		});
-		return data;
-	} catch (error: AxiosError | any) {
-		errorHandler(error);
-		throw new Error(`Request fail : ${url}`);
-	}
-}
-
-export async function authenticatedGetBlob(url: string, token: string) {
-	try {
-		const headers = jwtHeaders(token, 'application/pdf');
+		const headers = publicHeader();
 		const { data } = await axios<BlobPart>({
 			method: HTTP_VERBS.get,
 			url,
@@ -87,13 +61,9 @@ export async function authenticatedGetBlob(url: string, token: string) {
 	}
 }
 
-export async function authenticatedPutRequest<T>(
-	url: string,
-	data: T,
-	token: string
-) {
+export async function putRequest<T>(url: string, data: T) {
 	try {
-		const headers = jwtHeaders(token);
+		const headers = publicHeader();
 		await axios<T>({ method: HTTP_VERBS.put, url, headers, data });
 	} catch (error: AxiosError | any) {
 		errorHandler(error);

--- a/src/lib/surveys/getDepositProof.ts
+++ b/src/lib/surveys/getDepositProof.ts
@@ -1,7 +1,6 @@
-import { authenticatedGetBlob } from '../commons/axios-utils';
+import { getBlob } from '../commons/axios-utils';
 import { depositProof } from './api';
 
-export const getDepositProof =
-	(baseUrl: string) => async (unit: string, token: string) => {
-		return authenticatedGetBlob(depositProof(baseUrl, unit), token);
-	};
+export const getDepositProof = (baseUrl: string) => async (unit: string) => {
+	return getBlob(depositProof(baseUrl, unit));
+};

--- a/src/lib/surveys/getMetadataSurvey.ts
+++ b/src/lib/surveys/getMetadataSurvey.ts
@@ -1,11 +1,11 @@
 import moize from 'moize';
 import { MetadataSurvey } from '../../typeStromae/type';
-import { publicGetRequest } from '../commons/axios-utils';
+import { getRequest } from '../commons/axios-utils';
 
 import * as API from './api';
 
 export const getMetadataSurvey = (BASE_URL: string) =>
 	moize(async (survey: string): Promise<MetadataSurvey> => {
 		const url = API.surveyMetada(BASE_URL, survey);
-		return publicGetRequest<MetadataSurvey>(url);
+		return getRequest<MetadataSurvey>(url);
 	});

--- a/src/lib/surveys/getNomenclature.ts
+++ b/src/lib/surveys/getNomenclature.ts
@@ -1,11 +1,8 @@
-import { authenticatedGetRequest } from '../commons/axios-utils';
+import { getRequest } from '../commons/axios-utils';
 import { nomenclature } from './api';
 
 export const getNomenclature =
 	(BASE_URL: string) =>
-	(name: string, token: string): Promise<Array<unknown>> => {
-		return authenticatedGetRequest<Array<unknown>>(
-			nomenclature(BASE_URL, name),
-			token
-		);
+	(name: string): Promise<Array<unknown>> => {
+		return getRequest<Array<unknown>>(nomenclature(BASE_URL, name));
 	};

--- a/src/lib/surveys/getRequiredNomenclatures.ts
+++ b/src/lib/surveys/getRequiredNomenclatures.ts
@@ -1,12 +1,9 @@
-import { authenticatedGetRequest } from '../commons/axios-utils';
+import { getRequest } from '../commons/axios-utils';
 
 import { requiredNomenclature } from './api';
 
 export const getRequiredNomenclatures =
 	(BASE_URL: string) =>
-	(survey: string, token: string): Promise<Array<string>> => {
-		return authenticatedGetRequest<Array<string>>(
-			requiredNomenclature(BASE_URL, survey),
-			token
-		);
+	(survey: string): Promise<Array<string>> => {
+		return getRequest<Array<string>>(requiredNomenclature(BASE_URL, survey));
 	};

--- a/src/lib/surveys/getSurvey.ts
+++ b/src/lib/surveys/getSurvey.ts
@@ -1,4 +1,4 @@
-import { authenticatedGetRequest } from '../commons/axios-utils';
+import { getRequest } from '../commons/axios-utils';
 import { LunaticSource } from '../../typeLunatic/type-source';
 
 import { surveySource } from './api';
@@ -8,9 +8,6 @@ import { surveySource } from './api';
  */
 export const getSurvey =
 	(BASE_URL: string) =>
-	(survey: string, token: string): Promise<LunaticSource> => {
-		return authenticatedGetRequest<LunaticSource>(
-			surveySource(BASE_URL, survey),
-			token
-		);
+	(survey: string): Promise<LunaticSource> => {
+		return getRequest<LunaticSource>(surveySource(BASE_URL, survey));
 	};

--- a/src/lib/surveys/getSurveyUnit.ts
+++ b/src/lib/surveys/getSurveyUnit.ts
@@ -1,16 +1,12 @@
 import type { SurveyUnitData } from '../../typeStromae/type';
-import { authenticatedGetRequest } from '../commons/axios-utils';
-
+import { getRequest } from '../commons/axios-utils';
 import { surveyUnit } from './api';
 
 export const getSurveyUnitData =
 	(BASE_URL: string) =>
-	async (unit: string, token: string): Promise<SurveyUnitData> => {
+	async (unit: string): Promise<SurveyUnitData> => {
 		const { data, stateData, personalization } =
-			await authenticatedGetRequest<SurveyUnitData>(
-				surveyUnit(BASE_URL, unit),
-				token
-			);
+			await getRequest<SurveyUnitData>(surveyUnit(BASE_URL, unit));
 
 		return { data, stateData, personalization };
 	};

--- a/src/lib/surveys/putSurveyUnitData.ts
+++ b/src/lib/surveys/putSurveyUnitData.ts
@@ -1,13 +1,9 @@
 import { DataVariables } from '../../typeStromae/type';
-import { authenticatedPutRequest } from '../commons/axios-utils';
+import { putRequest } from '../commons/axios-utils';
 
 import { surveyUnitDataUrl } from './api';
 
 export const putSurveyUnitData =
-	(domain: string) => (data: DataVariables, unit: string, token: string) => {
-		return authenticatedPutRequest<DataVariables>(
-			surveyUnitDataUrl(domain, unit),
-			data,
-			token
-		);
+	(domain: string) => (data: DataVariables, unit: string) => {
+		return putRequest<DataVariables>(surveyUnitDataUrl(domain, unit), data);
 	};

--- a/src/lib/surveys/putSurveyUnitStateData.ts
+++ b/src/lib/surveys/putSurveyUnitStateData.ts
@@ -1,13 +1,9 @@
 import { StateData } from '../../typeStromae/type';
-import { authenticatedPutRequest } from '../commons/axios-utils';
+import { putRequest } from '../commons/axios-utils';
 
 import { surveyUnitStateDataUrl } from './api';
 
 export const putSurveyUnitStateData =
-	(domain: string) => async (state: StateData, unit: string, token: string) => {
-		await authenticatedPutRequest<StateData>(
-			surveyUnitStateDataUrl(domain, unit),
-			state,
-			token
-		);
+	(domain: string) => async (state: StateData, unit: string) => {
+		await putRequest<StateData>(surveyUnitStateDataUrl(domain, unit), state);
 	};

--- a/src/lib/surveys/surveysApi.ts
+++ b/src/lib/surveys/surveysApi.ts
@@ -19,25 +19,14 @@ const DOMAIN: string = process.env.REACT_APP_SURVEY_API_BASE_URL ?? '';
 
 export interface SurveyApi {
 	// any type JSon lunatic
-	getSurvey: (survey: string, token: string) => Promise<LunaticSource>;
-	getSurveyUnitData: (unit: string, token: string) => Promise<SurveyUnitData>;
+	getSurvey: (survey: string) => Promise<LunaticSource>;
+	getSurveyUnitData: (unit: string) => Promise<SurveyUnitData>;
 	getMetadataSurvey: (survey: string) => Promise<MetadataSurvey>;
-	getRequiredNomenclatures: (
-		survey: string,
-		token: string
-	) => Promise<Array<string>>;
-	getNomenclature: (name: string, token: string) => Promise<Array<any>>;
-	putSurveyUnitData: (
-		data: DataVariables,
-		unit: string,
-		token: string
-	) => Promise<void>;
-	putSurveyUnitStateData: (
-		stateData: StateData,
-		unit: string,
-		token: string
-	) => Promise<void>;
-	getDepositiProof: (unit: string, token: string) => Promise<BlobPart>;
+	getRequiredNomenclatures: (survey: string) => Promise<Array<string>>;
+	getNomenclature: (name: string) => Promise<Array<any>>;
+	putSurveyUnitData: (data: DataVariables, unit: string) => Promise<void>;
+	putSurveyUnitStateData: (stateData: StateData, unit: string) => Promise<void>;
+	getDepositiProof: (unit: string) => Promise<BlobPart>;
 }
 
 export const surveyApi: SurveyApi = {


### PR DESCRIPTION
La librairie axa gère elle-même l'ajout du jeton sur les requêtes. Aucune mention interne au jeton n'est nécessaire dans le code de l'application.