### PR TITLE
Feat/v3 redirection 301

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,6 @@
 GENERATE_SOURCEMAP=false
 SKIP_PREFLIGHT_CHECK=true
-# REACT_APP_SURVEY_API_BASE_URL=https://api-questionnaire-recensement.developpement6.insee.fr
-REACT_APP_SURVEY_API_BASE_URL=http://localhost:9000/mock-api
+REACT_APP_SURVEY_API_BASE_URL=https://api-questionnaire-recensement.developpement6.insee.fr
 REACT_APP_LUNATIC_LOADER_WORKER_PATH=/workers/lunatic-append-worker-0.3.0-experimental.js
 REACT_APP_LUNATIC_SEARCH_WORKER_PATH=/workers/lunatic-searching-worker-0.3.0-experimental.js
 REACT_APP_LUNATIC_LABEL_WORKER_PATH=/workers/lunatic-label-worker-0.3.0-experimental.js

--- a/.env
+++ b/.env
@@ -1,6 +1,7 @@
 GENERATE_SOURCEMAP=false
 SKIP_PREFLIGHT_CHECK=true
-REACT_APP_SURVEY_API_BASE_URL=https://api-questionnaire-recensement.developpement6.insee.fr
+# REACT_APP_SURVEY_API_BASE_URL=https://api-questionnaire-recensement.developpement6.insee.fr
+REACT_APP_SURVEY_API_BASE_URL=http://localhost:9000/mock-api
 REACT_APP_LUNATIC_LOADER_WORKER_PATH=/workers/lunatic-append-worker-0.3.0-experimental.js
 REACT_APP_LUNATIC_SEARCH_WORKER_PATH=/workers/lunatic-searching-worker-0.3.0-experimental.js
 REACT_APP_LUNATIC_LABEL_WORKER_PATH=/workers/lunatic-label-worker-0.3.0-experimental.js

--- a/mock-api/api/questionnaire/recensement/metadata/parametres.json
+++ b/mock-api/api/questionnaire/recensement/metadata/parametres.json
@@ -1,5 +1,5 @@
 {
-	"redirections": { "302": "/recensement/commune-kput" },
+	"redirections": { "301": "/recensement/commune-kput" },
 	"Header": {
 		"brandTop": {
 			"value": "République<br />française",

--- a/mock-api/api/questionnaire/recensement/metadata/parametres.json
+++ b/mock-api/api/questionnaire/recensement/metadata/parametres.json
@@ -1,4 +1,5 @@
 {
+	"redirections": { "302": "/recensement/commune-kput" },
 	"Header": {
 		"brandTop": {
 			"value": "République<br />française",
@@ -207,6 +208,10 @@
 				"title": "L'accessibilité on est à fond pour !",
 				"paragraphs": "Au RP on <a href=\"https://google.com\" target=\"_blank\"> pense </a>que c'est <button onclick=\"alert('I'll be king of the pirates!')\">presse me please!</button> super important l'accessibilité. Par contre c'est un peu pénible à impémenter donc on fait quand on le temps ou <b>envie</b> (ce qui revient un peu au même)."
 			}
+		],
+
+		"donnees-manquante": [
+			{ "type": "title", "title": "Données manquantes", "id": "toto" }
 		]
 	}
 }

--- a/mock-api/api/questionnaire/recensement/metadata/parametres.json
+++ b/mock-api/api/questionnaire/recensement/metadata/parametres.json
@@ -126,6 +126,9 @@
 	"Portal": {
 		"if you need": "use it !"
 	},
+	"errorPage": {
+		"subtitle": "La collecte dans votre commune n'est pas ouverte actuellement. Vous pourrez répondre au questionnaire dans quelques jours. Par avance, merci de votre participation."
+	},
 	"optionalPages": {
 		"plan-du-site": [
 			{ "type": "title", "title": "Plan du site", "id": "plan-du-site-title" },
@@ -217,10 +220,6 @@
 				"title": "L'accessibilité on est à fond pour !",
 				"paragraphs": "Au RP on <a href=\"https://google.com\" target=\"_blank\"> pense </a>que c'est <button onclick=\"alert('I'll be king of the pirates!')\">presse me please!</button> super important l'accessibilité. Par contre c'est un peu pénible à impémenter donc on fait quand on le temps ou <b>envie</b> (ce qui revient un peu au même)."
 			}
-		],
-
-		"donnees-manquante": [
-			{ "type": "title", "title": "Données manquantes", "id": "toto" }
 		]
 	}
 }

--- a/mock-api/api/survey-unit/kqhlz2/GET.js
+++ b/mock-api/api/survey-unit/kqhlz2/GET.js
@@ -2,8 +2,7 @@ const fs = require('fs');
 const path = require('path');
 
 module.exports = function (request, response) {
-	let targetFileName = './data.json';
-
+	let targetFileName = './data_.json';
 	// Check is a type parameter exist
 	if (request.query.type) {
 		// Generate a new targetfilename with that type parameter
@@ -14,7 +13,8 @@ module.exports = function (request, response) {
 	try {
 		fs.accessSync(filePath);
 	} catch (err) {
-		return response.status(404);
+		response.statusCode = 302;
+		response.end();
 	}
 	// Respond with filePath
 	response.sendFile(filePath);

--- a/mock-api/api/survey-unit/kqhlz2/GET.js
+++ b/mock-api/api/survey-unit/kqhlz2/GET.js
@@ -13,7 +13,7 @@ module.exports = function (request, response) {
 	try {
 		fs.accessSync(filePath);
 	} catch (err) {
-		response.statusCode = 302;
+		response.statusCode = 301;
 		response.end();
 	}
 	// Respond with filePath

--- a/mock-api/api/survey-unit/s5clyy/GET.js
+++ b/mock-api/api/survey-unit/s5clyy/GET.js
@@ -2,8 +2,7 @@ const fs = require('fs');
 const path = require('path');
 
 module.exports = function (request, response) {
-	let targetFileName = './data.json';
-
+	let targetFileName = './data_.json';
 	// Check is a type parameter exist
 	if (request.query.type) {
 		// Generate a new targetfilename with that type parameter
@@ -14,7 +13,8 @@ module.exports = function (request, response) {
 	try {
 		fs.accessSync(filePath);
 	} catch (err) {
-		return response.status(404);
+		response.statusCode = 301;
+		response.end();
 	}
 	// Respond with filePath
 	response.sendFile(filePath);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"@codegouvfr/react-dsfr": "^0.75.3",
 		"@emotion/react": "^11.10.5",
 		"@emotion/styled": "^11.10.5",
-		"@inseefr/lunatic": "2.5.2-beta",
+		"@inseefr/lunatic": "2.6.1",
 		"@inseefr/lunatic-dsfr": "0.0.36",
 		"@mui/material": "^5.11.8",
 		"@testing-library/jest-dom": "^5.16.5",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"@emotion/react": "^11.10.5",
 		"@emotion/styled": "^11.10.5",
 		"@inseefr/lunatic": "2.5.2-beta",
-		"@inseefr/lunatic-dsfr": "0.0.31",
+		"@inseefr/lunatic-dsfr": "0.0.36",
 		"@mui/material": "^5.11.8",
 		"@testing-library/jest-dom": "^5.16.5",
 		"@testing-library/react": "^13.4.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,68 +9,68 @@ import { Visualize } from './pages/visualize/Visualize';
 import { AuthProvider } from './components/auth';
 import { RoutingPortail, Portail } from './pages/portail';
 import { Optional } from './pages/optional';
-import { ErrorRedirection } from './pages/error/Error';
+import { RouteError } from './pages/error/Error';
 
 const router = createBrowserRouter([
 	{
 		path: '/questionnaire/:survey',
 		element: <Portail />,
-		errorElement: <ErrorRedirection />,
+		errorElement: <RouteError />,
 	},
 	{
 		path: '/questionnaire/:survey/unite-enquetee/:unit/post-envoi',
 		element: <PostSubmit />,
-		errorElement: <ErrorRedirection />,
+		errorElement: <RouteError />,
 	},
 	{
 		path: '/questionnaire/:survey/unite-enquetee/:unit/accueil',
 		element: <Welcome />,
-		errorElement: <ErrorRedirection />,
+		errorElement: <RouteError />,
 	},
 	{
 		path: '/questionnaire/:survey/unite-enquetee/:unit/deconnexion',
 		element: <Deconnexion />,
-		errorElement: <ErrorRedirection />,
+		errorElement: <RouteError />,
 	},
 	{
 		path: '/questionnaire/:survey/unite-enquetee/:unit',
 		element: <Questionnaire />,
-		errorElement: <ErrorRedirection />,
+		errorElement: <RouteError />,
 	},
 	{
 		path: '/read-only/questionnaire/:survey/unite-enquetee/:unit',
 		element: <QuestionnaireReadOnly />,
-		errorElement: <ErrorRedirection />,
+		errorElement: <RouteError />,
 	},
 	{
 		path: '/questionnaire/:survey/301/:errorType',
-		element: <ErrorRedirection code={301} />,
-		errorElement: <ErrorRedirection />,
+		element: <RouteError code={301} />,
+		errorElement: <RouteError />,
 	},
 	{
 		path: '/questionnaire/:survey/:optional',
 		element: <Optional />,
-		errorElement: <ErrorRedirection />,
+		errorElement: <RouteError />,
 	},
 	{
 		path: '/visualize',
 		element: <Visualize />,
-		errorElement: <ErrorRedirection />,
+		errorElement: <RouteError />,
 	},
 	{
 		path: '/404',
-		element: <ErrorRedirection />,
-		errorElement: <ErrorRedirection />,
+		element: <RouteError />,
+		errorElement: <RouteError />,
 	},
 	{
 		path: '/301',
-		element: <ErrorRedirection code={301} />,
-		errorElement: <ErrorRedirection />,
+		element: <RouteError code={301} />,
+		errorElement: <RouteError />,
 	},
 	{
 		path: '/',
 		element: <RoutingPortail />,
-		errorElement: <ErrorRedirection />,
+		errorElement: <RouteError />,
 	},
 ]);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,73 +5,72 @@ import { QuestionnaireReadOnly } from './pages/questionnaireReadOnly';
 import { Deconnexion } from './pages/deconnexion';
 import { Welcome } from './pages/welcome';
 import { PostSubmit } from './pages/postSubmit';
-
-import { Error } from './pages/error';
 import { Visualize } from './pages/visualize/Visualize';
 import { AuthProvider } from './components/auth';
 import { RoutingPortail, Portail } from './pages/portail';
 import { Optional } from './pages/optional';
+import { ErrorRedirection } from './pages/error/Error';
 
 const router = createBrowserRouter([
 	{
 		path: '/questionnaire/:survey',
 		element: <Portail />,
-		errorElement: <Error />,
+		errorElement: <ErrorRedirection />,
 	},
 	{
 		path: '/questionnaire/:survey/unite-enquetee/:unit/post-envoi',
 		element: <PostSubmit />,
-		errorElement: <Error />,
+		errorElement: <ErrorRedirection />,
 	},
 	{
 		path: '/questionnaire/:survey/unite-enquetee/:unit/accueil',
 		element: <Welcome />,
-		errorElement: <Error />,
+		errorElement: <ErrorRedirection />,
 	},
 	{
 		path: '/questionnaire/:survey/unite-enquetee/:unit/deconnexion',
 		element: <Deconnexion />,
-		errorElement: <Error />,
+		errorElement: <ErrorRedirection />,
 	},
 	{
 		path: '/questionnaire/:survey/unite-enquetee/:unit',
 		element: <Questionnaire />,
-		errorElement: <Error />,
+		errorElement: <ErrorRedirection />,
 	},
 	{
 		path: '/read-only/questionnaire/:survey/unite-enquetee/:unit',
 		element: <QuestionnaireReadOnly />,
-		errorElement: <Error />,
+		errorElement: <ErrorRedirection />,
 	},
 	{
 		path: '/questionnaire/:survey/301',
-		element: <Error code={301} />,
-		errorElement: <Error />,
+		element: <ErrorRedirection code={301} />,
+		errorElement: <ErrorRedirection />,
 	},
 	{
 		path: '/questionnaire/:survey/:optional',
 		element: <Optional />,
-		errorElement: <Error />,
+		errorElement: <ErrorRedirection />,
 	},
 	{
 		path: '/visualize',
 		element: <Visualize />,
-		errorElement: <Error />,
+		errorElement: <ErrorRedirection />,
 	},
 	{
 		path: '/404',
-		element: <Error />,
-		errorElement: <Error />,
+		element: <ErrorRedirection />,
+		errorElement: <ErrorRedirection />,
 	},
 	{
 		path: '/301',
-		element: <Error code={301} />,
-		errorElement: <Error />,
+		element: <ErrorRedirection code={301} />,
+		errorElement: <ErrorRedirection />,
 	},
 	{
 		path: '/',
 		element: <RoutingPortail />,
-		errorElement: <Error />,
+		errorElement: <ErrorRedirection />,
 	},
 ]);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,11 @@ const router = createBrowserRouter([
 		errorElement: <Error />,
 	},
 	{
+		path: '/questionnaire/:survey/301',
+		element: <Error code={301} />,
+		errorElement: <Error />,
+	},
+	{
 		path: '/questionnaire/:survey/:optional',
 		element: <Optional />,
 		errorElement: <Error />,
@@ -56,11 +61,6 @@ const router = createBrowserRouter([
 	{
 		path: '/404',
 		element: <Error />,
-		errorElement: <Error />,
-	},
-	{
-		path: '/301/:survey',
-		element: <Error code={301} />,
 		errorElement: <Error />,
 	},
 	{

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,6 +59,16 @@ const router = createBrowserRouter([
 		errorElement: <Error />,
 	},
 	{
+		path: '/302/:survey',
+		element: <Error code={302} />,
+		errorElement: <Error />,
+	},
+	{
+		path: '/302',
+		element: <Error code={302} />,
+		errorElement: <Error />,
+	},
+	{
 		path: '/',
 		element: <RoutingPortail />,
 		errorElement: <Error />,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,7 +43,7 @@ const router = createBrowserRouter([
 		errorElement: <ErrorRedirection />,
 	},
 	{
-		path: '/questionnaire/:survey/301',
+		path: '/questionnaire/:survey/301/:errorType',
 		element: <ErrorRedirection code={301} />,
 		errorElement: <ErrorRedirection />,
 	},

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,13 +59,13 @@ const router = createBrowserRouter([
 		errorElement: <Error />,
 	},
 	{
-		path: '/302/:survey',
-		element: <Error code={302} />,
+		path: '/301/:survey',
+		element: <Error code={301} />,
 		errorElement: <Error />,
 	},
 	{
-		path: '/302',
-		element: <Error code={302} />,
+		path: '/301',
+		element: <Error code={301} />,
 		errorElement: <Error />,
 	},
 	{

--- a/src/components/orchestrator/LoadSourceData.tsx
+++ b/src/components/orchestrator/LoadSourceData.tsx
@@ -8,7 +8,7 @@ import { loadSourceDataContext } from '../loadSourceData/LoadSourceDataContext';
 import { CloneElements } from './CloneElements';
 import { OrchestratorProps } from './Orchestrator';
 import { useRemote } from './useRemote';
-import { uri302, uri404 } from '../../lib/domainUri';
+import { uri301, uri404 } from '../../lib/domainUri';
 
 type LoadSourceDataProps = {
 	onChange?: (args: any) => void;
@@ -25,8 +25,8 @@ export function LoadSourceData({
 		useContext(loadSourceDataContext);
 
 	function navigateError(code?: number) {
-		if (code === 302) {
-			navigate(uri302(survey));
+		if (code === 301) {
+			navigate(uri301(survey));
 		} else {
 			navigate(uri404());
 		}

--- a/src/components/orchestrator/LoadSourceData.tsx
+++ b/src/components/orchestrator/LoadSourceData.tsx
@@ -19,7 +19,6 @@ export type responseData = {
 	message: string;
 };
 
-//
 export function LoadSourceData({
 	children,
 	onChange,
@@ -30,10 +29,9 @@ export function LoadSourceData({
 		useContext(loadSourceDataContext);
 
 	function navigateError(data?: responseData) {
-		if (data) {
-			const { status, message } = data;
-			if (status === 301) {
-				navigate(uri301(survey, message));
+		if (data?.status) {
+			if (data.status === 301) {
+				navigate(uri301(survey, data.message));
 			} else {
 				navigate(uri404());
 			}

--- a/src/components/orchestrator/LoadSourceData.tsx
+++ b/src/components/orchestrator/LoadSourceData.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, useCallback, useContext } from 'react';
+import { PropsWithChildren, useContext } from 'react';
 import { useNavigate, useParams } from 'react-router';
 
 import { LunaticSource } from '../../typeLunatic/type-source';

--- a/src/components/orchestrator/LoadSourceData.tsx
+++ b/src/components/orchestrator/LoadSourceData.tsx
@@ -1,5 +1,5 @@
-import { PropsWithChildren, useContext } from 'react';
-import { useNavigate } from 'react-router';
+import { PropsWithChildren, useCallback, useContext } from 'react';
+import { useNavigate, useParams } from 'react-router';
 
 import { LunaticSource } from '../../typeLunatic/type-source';
 import { MetadataSurvey, SurveyUnitData } from '../../typeStromae/type';
@@ -8,7 +8,7 @@ import { loadSourceDataContext } from '../loadSourceData/LoadSourceDataContext';
 import { CloneElements } from './CloneElements';
 import { OrchestratorProps } from './Orchestrator';
 import { useRemote } from './useRemote';
-import { uri404 } from '../../lib/domainUri';
+import { uri302, uri404 } from '../../lib/domainUri';
 
 type LoadSourceDataProps = {
 	onChange?: (args: any) => void;
@@ -19,13 +19,19 @@ export function LoadSourceData({
 	children,
 	onChange,
 }: PropsWithChildren<LoadSourceDataProps>) {
+	const { survey } = useParams();
 	const navigate = useNavigate();
 	const { getSurvey, getSurveyUnitData, getReferentiel, getMetadata } =
 		useContext(loadSourceDataContext);
 
-	function navigateError() {
-		navigate(uri404());
+	function navigateError(code?: number) {
+		if (code === 302) {
+			navigate(uri302(survey));
+		} else {
+			navigate(uri404());
+		}
 	}
+
 	const metadata = useRemote<MetadataSurvey>(getMetadata, navigateError);
 	const source = useRemote<LunaticSource>(getSurvey, navigateError);
 	const surveyUnitData = useRemote<SurveyUnitData>(

--- a/src/components/orchestrator/LoadSourceData.tsx
+++ b/src/components/orchestrator/LoadSourceData.tsx
@@ -14,6 +14,11 @@ type LoadSourceDataProps = {
 	onChange?: (args: any) => void;
 };
 
+export type responseData = {
+	status: number;
+	message: string;
+};
+
 //
 export function LoadSourceData({
 	children,
@@ -24,11 +29,14 @@ export function LoadSourceData({
 	const { getSurvey, getSurveyUnitData, getReferentiel, getMetadata } =
 		useContext(loadSourceDataContext);
 
-	function navigateError(code?: number) {
-		if (code === 301) {
-			navigate(uri301(survey));
-		} else {
-			navigate(uri404());
+	function navigateError(data?: responseData) {
+		if (data) {
+			const { status, message } = data;
+			if (status === 301) {
+				navigate(uri301(survey, message));
+			} else {
+				navigate(uri404());
+			}
 		}
 	}
 

--- a/src/components/orchestrator/useRemote.tsx
+++ b/src/components/orchestrator/useRemote.tsx
@@ -1,4 +1,3 @@
-import { AxiosError } from 'axios';
 import { useRef, useEffect, useState } from 'react';
 
 const controller = new AbortController();
@@ -28,7 +27,7 @@ export function useRemote<T>(
 				(async function () {
 					try {
 						setResult(await cally());
-					} catch (e: any | AxiosError) {
+					} catch (e: any) {
 						const code = e?.response?.status;
 						onfail(code);
 					}

--- a/src/components/orchestrator/useRemote.tsx
+++ b/src/components/orchestrator/useRemote.tsx
@@ -1,4 +1,5 @@
 import { useRef, useEffect, useState } from 'react';
+import { responseData } from './LoadSourceData';
 
 const controller = new AbortController();
 
@@ -15,7 +16,7 @@ function nothing() {}
  */
 export function useRemote<T>(
 	cally: (() => Promise<T | undefined>) | undefined,
-	onfail: (code?: number) => void = nothing
+	onfail: (data?: responseData) => void = nothing
 ): T | undefined {
 	const [result, setResult] = useState<T | undefined>(undefined);
 	const alreadyDone = useRef(false);
@@ -28,8 +29,8 @@ export function useRemote<T>(
 					try {
 						setResult(await cally());
 					} catch (e: any) {
-						const code = e?.response?.status;
-						onfail(code);
+						const data = e?.response.data;
+						onfail(data);
 					}
 				})();
 			}

--- a/src/components/orchestrator/useRemote.tsx
+++ b/src/components/orchestrator/useRemote.tsx
@@ -1,3 +1,4 @@
+import { AxiosError } from 'axios';
 import { useRef, useEffect, useState } from 'react';
 
 const controller = new AbortController();
@@ -15,7 +16,7 @@ function nothing() {}
  */
 export function useRemote<T>(
 	cally: (() => Promise<T | undefined>) | undefined,
-	onfail: () => void = nothing
+	onfail: (code?: number) => void = nothing
 ): T | undefined {
 	const [result, setResult] = useState<T | undefined>(undefined);
 	const alreadyDone = useRef(false);
@@ -27,8 +28,9 @@ export function useRemote<T>(
 				(async function () {
 					try {
 						setResult(await cally());
-					} catch (e) {
-						onfail();
+					} catch (e: any | AxiosError) {
+						const code = e?.response?.status;
+						onfail(code);
 					}
 				})();
 			}

--- a/src/lib/domainUri/uri.ts
+++ b/src/lib/domainUri/uri.ts
@@ -6,7 +6,7 @@ export function uri404() {
 }
 
 export function uri301(survey?: string) {
-	return `/301${survey ? `/${survey}` : ''}`;
+	return `/${survey ? `questionnaire/${survey}/301` : '301'}`;
 }
 
 /*

--- a/src/lib/domainUri/uri.ts
+++ b/src/lib/domainUri/uri.ts
@@ -6,10 +6,7 @@ export function uri404() {
 }
 
 export function uri302(survey?: string) {
-	if (survey) {
-		return `/${survey}/donnees-manquante`;
-	}
-	return uri404();
+	return `/302${survey ? `/${survey}` : ''}`;
 }
 
 /*

--- a/src/lib/domainUri/uri.ts
+++ b/src/lib/domainUri/uri.ts
@@ -5,8 +5,8 @@ export function uri404() {
 	return '/404';
 }
 
-export function uri302(survey?: string) {
-	return `/302${survey ? `/${survey}` : ''}`;
+export function uri301(survey?: string) {
+	return `/301${survey ? `/${survey}` : ''}`;
 }
 
 /*

--- a/src/lib/domainUri/uri.ts
+++ b/src/lib/domainUri/uri.ts
@@ -5,6 +5,10 @@ export function uri404() {
 	return '/404';
 }
 
+// Redirect depending on survey and error message
+// If survey doesn't exist, the url returns `/301`
+// If survey exists, the url returns `/questionnaire/:survey/301/temporairement-indisponible`
+// Depending on the error message, the last parameter can be replaced by `post-collecte` or `pre-collecte`
 export function uri301(survey?: string, message?: string) {
 	const surveyUrl = survey ? `questionnaire/${survey}/301` : '301';
 	let status = '/temporairement-indisponible';

--- a/src/lib/domainUri/uri.ts
+++ b/src/lib/domainUri/uri.ts
@@ -6,7 +6,8 @@ export function uri404() {
 }
 
 export function uri301(survey?: string) {
-	return `/${survey ? `questionnaire/${survey}/301` : '301'}`;
+	const surveyUrl = survey ? `questionnaire/${survey}/301` : '301';
+	return `/${surveyUrl}`;
 }
 
 /*

--- a/src/lib/domainUri/uri.ts
+++ b/src/lib/domainUri/uri.ts
@@ -5,6 +5,13 @@ export function uri404() {
 	return '/404';
 }
 
+export function uri302(survey?: string) {
+	if (survey) {
+		return `/${survey}/donnees-manquante`;
+	}
+	return uri404();
+}
+
 /*
  * ressource principale du site, affichant le questionnaire.
  */

--- a/src/lib/domainUri/uri.ts
+++ b/src/lib/domainUri/uri.ts
@@ -12,7 +12,6 @@ export function uri404() {
 export function uri301(survey?: string, message?: string) {
 	const surveyUrl = survey ? `questionnaire/${survey}/301` : '301';
 	let status = '/temporairement-indisponible';
-	// TODO: access error status directly from API
 	// 301 error can be reached either before or after the collection period
 	// Depending on whether it is before or after, we need to display a different message
 	// At the moment, the only differentiating information that we get from the API is in the `message`

--- a/src/lib/domainUri/uri.ts
+++ b/src/lib/domainUri/uri.ts
@@ -5,9 +5,19 @@ export function uri404() {
 	return '/404';
 }
 
-export function uri301(survey?: string) {
+export function uri301(survey?: string, message?: string) {
 	const surveyUrl = survey ? `questionnaire/${survey}/301` : '301';
-	return `/${surveyUrl}`;
+	let status = '/temporairement-indisponible';
+	// TODO: access error status directly from API
+	// 301 error can be reached either before or after the collection period
+	// Depending on whether it is before or after, we need to display a different message
+	// At the moment, the only differentiating information that we get from the API is in the `message`
+	if (message?.includes('cloturée')) {
+		status = '/post-collecte';
+	} else if (message?.includes('pas encore ouverte')) {
+		status = '/pre-collecte';
+	}
+	return `/${surveyUrl}${status}`;
 }
 
 /*

--- a/src/pages/error/Error.test.tsx
+++ b/src/pages/error/Error.test.tsx
@@ -1,9 +1,9 @@
 import { render, screen } from '@testing-library/react';
 
-import { ErrorRedirection } from './Error';
+import { RouteError } from './Error';
 
 test('renders Route', () => {
-	render(<ErrorRedirection />);
+	render(<RouteError />);
 	const route = screen.getByTestId('error-page');
 	expect(route).toBeInTheDocument();
 });

--- a/src/pages/error/Error.test.tsx
+++ b/src/pages/error/Error.test.tsx
@@ -1,9 +1,9 @@
 import { render, screen } from '@testing-library/react';
 
-import { Error } from './Error';
+import { ErrorRedirection } from './Error';
 
 test('renders Route', () => {
-	render(<Error />);
+	render(<ErrorRedirection />);
 	const route = screen.getByTestId('error-page');
 	expect(route).toBeInTheDocument();
 });

--- a/src/pages/error/Error.tsx
+++ b/src/pages/error/Error.tsx
@@ -2,7 +2,7 @@ import { useParams } from 'react-router-dom';
 import { LoadFromApi } from '../../components/loadSourceData/LoadFromApi';
 import { ErrorPage } from './html/ErrorPage';
 
-export function Error({ code }: { code?: number }) {
+export function ErrorRedirection({ code }: { code?: number }) {
 	const { survey } = useParams();
 	return (
 		<LoadFromApi survey={survey}>

--- a/src/pages/error/Error.tsx
+++ b/src/pages/error/Error.tsx
@@ -1,77 +1,12 @@
-import { isRouteErrorResponse, useRouteError } from 'react-router-dom';
-import { Button } from '@codegouvfr/react-dsfr/Button';
-import TechnicalError from '@codegouvfr/react-dsfr/dsfr/artwork/pictograms/system/technical-error.svg';
-import { useDocumentTitle } from '../../utils/useDocumentTitle';
-import { fr } from '@codegouvfr/react-dsfr';
+import { useParams } from 'react-router-dom';
+import { LoadFromApi } from '../../components/loadSourceData/LoadFromApi';
+import { ErrorPage } from './html/ErrorPage';
 
-export function Error() {
-	const error = useRouteError();
-	const errorStatus = isRouteErrorResponse(error) && error.status;
-	useDocumentTitle('Page non trouvée');
+export function Error({ code }: { code?: number }) {
+	const { survey } = useParams();
 	return (
-		<div className={fr.cx('fr-container')}>
-			<div
-				className={fr.cx(
-					'fr-grid-row',
-					'fr-grid-row--center',
-					'fr-grid-row--middle',
-					'fr-mt-6w',
-					'fr-mt-md-12w'
-				)}
-			>
-				<div className={fr.cx('fr-col-lg-6', 'fr-col-12')}>
-					<h1>Page non trouvée</h1>
-					{errorStatus && <span>Erreur {errorStatus}</span>}
-					<p className={fr.cx('fr-mt-3w', 'fr-text--lead')}>
-						La page que vous cherchez est introuvable. Excusez-nous pour la gêne
-						occasionnée.
-					</p>
-					<p className={fr.cx('fr-mt-3w')}>
-						Si vous avez tapé l’adresse web dans le navigateur, vérifiez qu’elle
-						est correcte. La page n’est peut-être plus disponible. Dans ce cas,
-						pour continuer votre visite vous pouvez retourner sur la page
-						d’accueil. Sinon contactez-nous pour que l’on puisse vous aider.
-					</p>
-					<Button
-						size="large"
-						linkProps={{
-							href: '/',
-						}}
-					>
-						Retourner à la page d'accueil
-					</Button>
-				</div>
-				<div
-					className={fr.cx(
-						'fr-col-lg-3',
-						'fr-col-offset-lg-1',
-						'fr-col-8',
-						'fr-mt-6w',
-						'fr-col--middle'
-					)}
-				>
-					<svg
-						className={fr.cx('fr-artwork')}
-						aria-hidden="true"
-						viewBox="0 0 80 80"
-						width="200px"
-						height="200px"
-					>
-						<use
-							className={fr.cx('fr-artwork-decorative')}
-							xlinkHref={`${TechnicalError}#artwork-decorative`}
-						></use>
-						<use
-							className={fr.cx('fr-artwork-minor')}
-							xlinkHref={`${TechnicalError}#artwork-minor`}
-						></use>
-						<use
-							className={fr.cx('fr-artwork-major')}
-							xlinkHref={`${TechnicalError}#artwork-major`}
-						></use>
-					</svg>
-				</div>
-			</div>
-		</div>
+		<LoadFromApi survey={survey}>
+			<ErrorPage code={code} />
+		</LoadFromApi>
 	);
 }

--- a/src/pages/error/Error.tsx
+++ b/src/pages/error/Error.tsx
@@ -2,7 +2,7 @@ import { useParams } from 'react-router-dom';
 import { LoadFromApi } from '../../components/loadSourceData/LoadFromApi';
 import { ErrorPage } from './html/ErrorPage';
 
-export function ErrorRedirection({ code }: { code?: number }) {
+export function RouteError({ code }: { code?: number }) {
 	const { survey, errorType } = useParams();
 	return (
 		<LoadFromApi survey={survey}>

--- a/src/pages/error/Error.tsx
+++ b/src/pages/error/Error.tsx
@@ -3,10 +3,10 @@ import { LoadFromApi } from '../../components/loadSourceData/LoadFromApi';
 import { ErrorPage } from './html/ErrorPage';
 
 export function ErrorRedirection({ code }: { code?: number }) {
-	const { survey } = useParams();
+	const { survey, errorType } = useParams();
 	return (
 		<LoadFromApi survey={survey}>
-			<ErrorPage code={code} />
+			<ErrorPage code={code} errorType={errorType} />
 		</LoadFromApi>
 	);
 }

--- a/src/pages/error/html/ErrorPage.tsx
+++ b/src/pages/error/html/ErrorPage.tsx
@@ -16,7 +16,7 @@ function ErrorStatus({
 	code?: number;
 }) {
 	if (errorStatus || code) {
-		return <span>Erreur {errorStatus ? errorStatus : code}</span>;
+		return <span>Erreur {errorStatus || code}</span>;
 	}
 	return null;
 }
@@ -27,7 +27,7 @@ function getTextFor(code?: number, content?: Record<string, string>) {
 
 	const subtitle =
 		code && code === 301
-			? content?.subtitle ||
+			? content?.subtitle ??
 			  "La page que vous cherchez n'est pas disponible pour le moment.  Veuillez réessayez ultérieurement."
 			: 'La page que vous cherchez est introuvable. Excusez-nous pour la gêne occasionnée.';
 

--- a/src/pages/error/html/ErrorPage.tsx
+++ b/src/pages/error/html/ErrorPage.tsx
@@ -94,14 +94,16 @@ export function ErrorPage({
 					<ErrorStatus errorStatus={errorStatus} code={code} />
 					<p className={fr.cx('fr-mt-3w', 'fr-text--lead')}>{subtitle}</p>
 					<p className={fr.cx('fr-mt-3w')}>{paragraph}</p>
-					<Button
-						size="large"
-						linkProps={{
-							to: '/',
-						}}
-					>
-						Retourner à la page d'accueil
-					</Button>
+					{code !== 301 && (
+						<Button
+							size="large"
+							linkProps={{
+								to: '/',
+							}}
+						>
+							Retourner à la page d'accueil
+						</Button>
+					)}
 				</div>
 				<div
 					className={fr.cx(

--- a/src/pages/error/html/ErrorPage.tsx
+++ b/src/pages/error/html/ErrorPage.tsx
@@ -26,13 +26,13 @@ function ErrorStatus({
 }
 
 function getTextFor(code?: number, content?: ContentType, errorType?: string) {
-	if (code && code === 301 && errorType) {
+	if (code === 301 && errorType) {
 		return {
 			title: 'Temporairement indisponible',
 			subtitle: content?.subtitle && content?.subtitle[errorType],
 			paragraph: content?.paragraph && content?.paragraph[errorType],
 		};
-	} else if (code && code === 301) {
+	} else if (code === 301) {
 		return {
 			title: 'Temporairement indisponible',
 			subtitle:

--- a/src/pages/error/html/ErrorPage.tsx
+++ b/src/pages/error/html/ErrorPage.tsx
@@ -21,6 +21,24 @@ function ErrorStatus({
 	return null;
 }
 
+function getTextFor(code?: number, content?: Record<string, string>) {
+	const title =
+		code && code === 301 ? 'Temporairement indisponible' : 'Page non trouvée';
+
+	const subtitle =
+		code && code === 301
+			? content?.subtitle ||
+			  "La page que vous cherchez n'est pas disponible pour le moment.  Veuillez réessayez ultérieurement."
+			: 'La page que vous cherchez est introuvable. Excusez-nous pour la gêne occasionnée.';
+
+	const paragraph =
+		code && code === 301
+			? content?.paragraph
+			: 'Si vous avez tapé l’adresse web dans le navigateur, vérifiez qu’elle est correcte. La page n’est peut-être plus disponible. Dans ce cas, pour continuer votre visite vous pouvez retourner sur la page d’accueil. Sinon contactez-nous pour que l’on puisse vous aider.';
+
+	return { title, subtitle, paragraph };
+}
+
 export function ErrorPage({ code }: { code?: number }) {
 	const { getMetadata } = useContext(loadSourceDataContext);
 	const [content, setContent] = useState<Record<string, string>>();
@@ -28,20 +46,7 @@ export function ErrorPage({ code }: { code?: number }) {
 	const error = useRouteError();
 	const errorStatus = isRouteErrorResponse(error) && error.status;
 
-	const titleText =
-		code && code === 301 ? 'Temporairement indisponible' : 'Page non trouvée';
-
-	const subtitleText =
-		code && code === 301
-			? content?.subtitle ||
-			  "La page que vous cherchez n'est pas disponible pour le moment.  Veuillez réessayez ultérieurement."
-			: 'La page que vous cherchez est introuvable. Excusez-nous pour la gêne occasionnée.';
-
-	const paragraphText =
-		code && code === 301
-			? content?.paragraph
-			: 'Si vous avez tapé l’adresse web dans le navigateur, vérifiez qu’elle est correcte. La page n’est peut-être plus disponible. Dans ce cas, pour continuer votre visite vous pouvez retourner sur la page d’accueil. Sinon contactez-nous pour que l’on puisse vous aider.';
-
+	const { title, subtitle, paragraph } = getTextFor(code, content);
 	useEffect(() => {
 		if (metadata) {
 			if (metadata?.errorPage) {
@@ -54,7 +59,7 @@ export function ErrorPage({ code }: { code?: number }) {
 		setMetadata(await getMetadata());
 	}, [getMetadata]);
 
-	useDocumentTitle(titleText);
+	useDocumentTitle(title);
 	return (
 		<div className={fr.cx('fr-container')}>
 			<div
@@ -67,10 +72,10 @@ export function ErrorPage({ code }: { code?: number }) {
 				)}
 			>
 				<div className={fr.cx('fr-col-lg-6', 'fr-col-12')}>
-					<h1>{titleText}</h1>
+					<h1>{title}</h1>
 					<ErrorStatus errorStatus={errorStatus} code={code} />
-					<p className={fr.cx('fr-mt-3w', 'fr-text--lead')}>{subtitleText}</p>
-					<p className={fr.cx('fr-mt-3w')}>{paragraphText}</p>
+					<p className={fr.cx('fr-mt-3w', 'fr-text--lead')}>{subtitle}</p>
+					<p className={fr.cx('fr-mt-3w')}>{paragraph}</p>
 					<Button
 						size="large"
 						linkProps={{

--- a/src/pages/error/html/ErrorPage.tsx
+++ b/src/pages/error/html/ErrorPage.tsx
@@ -29,16 +29,16 @@ export function ErrorPage({ code }: { code?: number }) {
 	const errorStatus = isRouteErrorResponse(error) && error.status;
 
 	const titleText =
-		code && code === 302 ? 'Temporairement indisponible' : 'Page non trouvée';
+		code && code === 301 ? 'Temporairement indisponible' : 'Page non trouvée';
 
 	const subtitleText =
-		code && code === 302
+		code && code === 301
 			? content?.subtitle ||
 			  "La page que vous cherchez n'est pas disponible pour le moment.  Veuillez réessayez ultérieurement."
 			: 'La page que vous cherchez est introuvable. Excusez-nous pour la gêne occasionnée.';
 
 	const paragraphText =
-		code && code === 302
+		code && code === 301
 			? content?.paragraph
 			: 'Si vous avez tapé l’adresse web dans le navigateur, vérifiez qu’elle est correcte. La page n’est peut-être plus disponible. Dans ce cas, pour continuer votre visite vous pouvez retourner sur la page d’accueil. Sinon contactez-nous pour que l’on puisse vous aider.';
 

--- a/src/pages/error/html/ErrorPage.tsx
+++ b/src/pages/error/html/ErrorPage.tsx
@@ -1,0 +1,116 @@
+import { isRouteErrorResponse, useRouteError } from 'react-router-dom';
+import { Button } from '@codegouvfr/react-dsfr/Button';
+import TechnicalError from '@codegouvfr/react-dsfr/dsfr/artwork/pictograms/system/technical-error.svg';
+import { useDocumentTitle } from '../../../utils/useDocumentTitle';
+import { fr } from '@codegouvfr/react-dsfr';
+import { useContext, useEffect, useState } from 'react';
+import { loadSourceDataContext } from '../../../components/loadSourceData/LoadSourceDataContext';
+import { MetadataSurvey } from '../../../typeStromae/type';
+import { useAsyncEffect } from '../../../hooks/useAsyncEffect';
+
+function ErrorStatus({
+	errorStatus,
+	code,
+}: {
+	errorStatus: number | false;
+	code?: number;
+}) {
+	if (errorStatus || code) {
+		return <span>Erreur {errorStatus ? errorStatus : code}</span>;
+	}
+	return null;
+}
+
+export function ErrorPage({ code }: { code?: number }) {
+	const { getMetadata } = useContext(loadSourceDataContext);
+	const [content, setContent] = useState<Record<string, string>>();
+	const [metadata, setMetadata] = useState<MetadataSurvey>();
+	const error = useRouteError();
+	const errorStatus = isRouteErrorResponse(error) && error.status;
+
+	const titleText =
+		code && code === 302 ? 'Temporairement indisponible' : 'Page non trouvée';
+
+	const subtitleText =
+		code && code === 302
+			? content?.subtitle ||
+			  "La page que vous cherchez n'est pas disponible pour le moment.  Veuillez réessayez ultérieurement."
+			: 'La page que vous cherchez est introuvable. Excusez-nous pour la gêne occasionnée.';
+
+	const paragraphText =
+		code && code === 302
+			? content?.paragraph
+			: 'Si vous avez tapé l’adresse web dans le navigateur, vérifiez qu’elle est correcte. La page n’est peut-être plus disponible. Dans ce cas, pour continuer votre visite vous pouvez retourner sur la page d’accueil. Sinon contactez-nous pour que l’on puisse vous aider.';
+
+	useEffect(() => {
+		if (metadata) {
+			if (metadata?.errorPage) {
+				setContent(metadata.errorPage);
+			}
+		}
+	}, [metadata]);
+
+	useAsyncEffect(async () => {
+		setMetadata(await getMetadata());
+	}, [getMetadata]);
+
+	useDocumentTitle(titleText);
+	return (
+		<div className={fr.cx('fr-container')}>
+			<div
+				className={fr.cx(
+					'fr-grid-row',
+					'fr-grid-row--center',
+					'fr-grid-row--middle',
+					'fr-mt-6w',
+					'fr-mt-md-12w'
+				)}
+			>
+				<div className={fr.cx('fr-col-lg-6', 'fr-col-12')}>
+					<h1>{titleText}</h1>
+					<ErrorStatus errorStatus={errorStatus} code={code} />
+					<p className={fr.cx('fr-mt-3w', 'fr-text--lead')}>{subtitleText}</p>
+					<p className={fr.cx('fr-mt-3w')}>{paragraphText}</p>
+					<Button
+						size="large"
+						linkProps={{
+							href: '/',
+						}}
+					>
+						Retourner à la page d'accueil
+					</Button>
+				</div>
+				<div
+					className={fr.cx(
+						'fr-col-lg-3',
+						'fr-col-offset-lg-1',
+						'fr-col-8',
+						'fr-mt-6w',
+						'fr-col--middle'
+					)}
+				>
+					<svg
+						className={fr.cx('fr-artwork')}
+						aria-hidden="true"
+						viewBox="0 0 80 80"
+						width="200px"
+						height="200px"
+					>
+						<use
+							className={fr.cx('fr-artwork-decorative')}
+							xlinkHref={`${TechnicalError}#artwork-decorative`}
+						></use>
+						<use
+							className={fr.cx('fr-artwork-minor')}
+							xlinkHref={`${TechnicalError}#artwork-minor`}
+						></use>
+						<use
+							className={fr.cx('fr-artwork-major')}
+							xlinkHref={`${TechnicalError}#artwork-major`}
+						></use>
+					</svg>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/pages/error/html/ErrorPage.tsx
+++ b/src/pages/error/html/ErrorPage.tsx
@@ -3,7 +3,7 @@ import { Button } from '@codegouvfr/react-dsfr/Button';
 import TechnicalError from '@codegouvfr/react-dsfr/dsfr/artwork/pictograms/system/technical-error.svg';
 import { useDocumentTitle } from '../../../utils/useDocumentTitle';
 import { fr } from '@codegouvfr/react-dsfr';
-import { useContext, useEffect, useState } from 'react';
+import { useContext, useEffect, useMemo, useState } from 'react';
 import { loadSourceDataContext } from '../../../components/loadSourceData/LoadSourceDataContext';
 import { MetadataSurvey } from '../../../typeStromae/type';
 import { useAsyncEffect } from '../../../hooks/useAsyncEffect';
@@ -41,19 +41,21 @@ function getTextFor(code?: number, content?: Record<string, string>) {
 
 export function ErrorPage({ code }: { code?: number }) {
 	const { getMetadata } = useContext(loadSourceDataContext);
-	const [content, setContent] = useState<Record<string, string>>();
 	const [metadata, setMetadata] = useState<MetadataSurvey>();
+
+	const content = useMemo(() => {
+		if (metadata?.errorPage) {
+			return metadata.errorPage;
+		}
+		return undefined;
+	}, [metadata]);
+
 	const error = useRouteError();
 	const errorStatus = isRouteErrorResponse(error) && error.status;
 
 	const { title, subtitle, paragraph } = getTextFor(code, content);
-	useEffect(() => {
-		if (metadata) {
-			if (metadata?.errorPage) {
-				setContent(metadata.errorPage);
-			}
-		}
-	}, [metadata]);
+
+	useEffect(() => {}, [metadata]);
 
 	useAsyncEffect(async () => {
 		setMetadata(await getMetadata());
@@ -79,7 +81,7 @@ export function ErrorPage({ code }: { code?: number }) {
 					<Button
 						size="large"
 						linkProps={{
-							href: '/',
+							to: '/',
 						}}
 					>
 						Retourner à la page d'accueil

--- a/src/pages/error/html/ErrorPage.tsx
+++ b/src/pages/error/html/ErrorPage.tsx
@@ -8,6 +8,11 @@ import { loadSourceDataContext } from '../../../components/loadSourceData/LoadSo
 import { MetadataSurvey } from '../../../typeStromae/type';
 import { useAsyncEffect } from '../../../hooks/useAsyncEffect';
 
+type ContentType = {
+	subtitle?: Record<string, string>;
+	paragraph?: Record<string, string>;
+};
+
 function ErrorStatus({
 	errorStatus,
 	code,
@@ -21,25 +26,36 @@ function ErrorStatus({
 	return null;
 }
 
-function getTextFor(code?: number, content?: Record<string, string>) {
-	const title =
-		code && code === 301 ? 'Temporairement indisponible' : 'Page non trouvée';
-
-	const subtitle =
-		code && code === 301
-			? content?.subtitle ??
-			  "La page que vous cherchez n'est pas disponible pour le moment.  Veuillez réessayez ultérieurement."
-			: 'La page que vous cherchez est introuvable. Excusez-nous pour la gêne occasionnée.';
-
-	const paragraph =
-		code && code === 301
-			? content?.paragraph
-			: 'Si vous avez tapé l’adresse web dans le navigateur, vérifiez qu’elle est correcte. La page n’est peut-être plus disponible. Dans ce cas, pour continuer votre visite vous pouvez retourner sur la page d’accueil. Sinon contactez-nous pour que l’on puisse vous aider.';
-
-	return { title, subtitle, paragraph };
+function getTextFor(code?: number, content?: ContentType, errorType?: string) {
+	if (code && code === 301) {
+		const title = 'Temporairement indisponible';
+		if (errorType) {
+			const subtitle = content?.subtitle && content?.subtitle[errorType];
+			const paragraph = content?.paragraph && content?.paragraph[errorType];
+			return { title, subtitle, paragraph };
+		} else {
+			const subtitle =
+				"La page que vous cherchez n'est pas disponible pour le moment.  Veuillez réessayez ultérieurement.";
+			const paragraph = null;
+			return { title, subtitle, paragraph };
+		}
+	} else {
+		const title = 'Page non trouvée';
+		const subtitle =
+			'La page que vous cherchez est introuvable. Excusez-nous pour la gêne occasionnée.';
+		const paragraph =
+			'votre visite vous pouvez retourner sur la page d’accueil. Sinon contactez-nous pour que l’on puisse vous aider.';
+		return { title, subtitle, paragraph };
+	}
 }
 
-export function ErrorPage({ code }: { code?: number }) {
+export function ErrorPage({
+	code,
+	errorType,
+}: {
+	code?: number;
+	errorType?: string;
+}) {
 	const { getMetadata } = useContext(loadSourceDataContext);
 	const [metadata, setMetadata] = useState<MetadataSurvey>();
 
@@ -53,7 +69,7 @@ export function ErrorPage({ code }: { code?: number }) {
 	const error = useRouteError();
 	const errorStatus = isRouteErrorResponse(error) && error.status;
 
-	const { title, subtitle, paragraph } = getTextFor(code, content);
+	const { title, subtitle, paragraph } = getTextFor(code, content, errorType);
 
 	useEffect(() => {}, [metadata]);
 

--- a/src/pages/error/html/ErrorPage.tsx
+++ b/src/pages/error/html/ErrorPage.tsx
@@ -3,10 +3,9 @@ import { Button } from '@codegouvfr/react-dsfr/Button';
 import TechnicalError from '@codegouvfr/react-dsfr/dsfr/artwork/pictograms/system/technical-error.svg';
 import { useDocumentTitle } from '../../../utils/useDocumentTitle';
 import { fr } from '@codegouvfr/react-dsfr';
-import { useContext, useEffect, useMemo, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { loadSourceDataContext } from '../../../components/loadSourceData/LoadSourceDataContext';
 import { MetadataSurvey } from '../../../typeStromae/type';
-import { useAsyncEffect } from '../../../hooks/useAsyncEffect';
 
 type ContentType = {
 	subtitle?: Record<string, string>;
@@ -27,25 +26,27 @@ function ErrorStatus({
 }
 
 function getTextFor(code?: number, content?: ContentType, errorType?: string) {
-	if (code && code === 301) {
-		const title = 'Temporairement indisponible';
-		if (errorType) {
-			const subtitle = content?.subtitle && content?.subtitle[errorType];
-			const paragraph = content?.paragraph && content?.paragraph[errorType];
-			return { title, subtitle, paragraph };
-		} else {
-			const subtitle =
-				"La page que vous cherchez n'est pas disponible pour le moment.  Veuillez réessayez ultérieurement.";
-			const paragraph = null;
-			return { title, subtitle, paragraph };
-		}
+	if (code && code === 301 && errorType) {
+		return {
+			title: 'Temporairement indisponible',
+			subtitle: content?.subtitle && content?.subtitle[errorType],
+			paragraph: content?.paragraph && content?.paragraph[errorType],
+		};
+	} else if (code && code === 301) {
+		return {
+			title: 'Temporairement indisponible',
+			subtitle:
+				"La page que vous cherchez n'est pas disponible pour le moment.  Veuillez réessayez ultérieurement.",
+			paragraph: null,
+		};
 	} else {
-		const title = 'Page non trouvée';
-		const subtitle =
-			'La page que vous cherchez est introuvable. Excusez-nous pour la gêne occasionnée.';
-		const paragraph =
-			'votre visite vous pouvez retourner sur la page d’accueil. Sinon contactez-nous pour que l’on puisse vous aider.';
-		return { title, subtitle, paragraph };
+		return {
+			title: 'Page non trouvée',
+			subtitle:
+				'La page que vous cherchez est introuvable. Excusez-nous pour la gêne occasionnée.',
+			paragraph:
+				'votre visite vous pouvez retourner sur la page d’accueil. Sinon contactez-nous pour que l’on puisse vous aider.',
+		};
 	}
 }
 
@@ -59,22 +60,18 @@ export function ErrorPage({
 	const { getMetadata } = useContext(loadSourceDataContext);
 	const [metadata, setMetadata] = useState<MetadataSurvey>();
 
-	const content = useMemo(() => {
-		if (metadata?.errorPage) {
-			return metadata.errorPage;
-		}
-		return undefined;
-	}, [metadata]);
+	const content = metadata?.errorPage;
 
 	const error = useRouteError();
 	const errorStatus = isRouteErrorResponse(error) && error.status;
 
 	const { title, subtitle, paragraph } = getTextFor(code, content, errorType);
 
-	useEffect(() => {}, [metadata]);
-
-	useAsyncEffect(async () => {
-		setMetadata(await getMetadata());
+	useEffect(() => {
+		getMetadata()
+			.then(setMetadata)
+			// eslint-disable-next-line no-console
+			.catch((e) => console.log(e));
 	}, [getMetadata]);
 
 	useDocumentTitle(title);

--- a/src/pages/error/index.tsx
+++ b/src/pages/error/index.tsx
@@ -1,1 +1,1 @@
-export { Error } from './Error';
+export { ErrorRedirection } from './Error';

--- a/src/pages/error/index.tsx
+++ b/src/pages/error/index.tsx
@@ -1,1 +1,1 @@
-export { ErrorRedirection } from './Error';
+export { RouteError } from './Error';

--- a/src/typeStromae/type.ts
+++ b/src/typeStromae/type.ts
@@ -158,4 +158,5 @@ export type MetadataSurvey = {
 	Header: HeaderType;
 	Footer: FooterType;
 	Submit: SubmitType;
+	redirections: Record<string, string>;
 } & { optionalPages: Record<string, OptionalPage> };

--- a/src/typeStromae/type.ts
+++ b/src/typeStromae/type.ts
@@ -159,4 +159,5 @@ export type MetadataSurvey = {
 	Footer: FooterType;
 	Submit: SubmitType;
 	redirections: Record<string, string>;
+	errorPage: Record<string, string>;
 } & { optionalPages: Record<string, OptionalPage> };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1127,6 +1127,13 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
+"@babel/runtime@^7.22.15":
+  version "7.22.15"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.15.tgz#38f46494ccf6cf020bd4eed7124b425e83e523b8"
+  integrity sha512-T0O+aa+4w0u06iNmapipJXMV4HoUir03hpx3/YqXXhu9xim3w+dVphjFWl1OH8NbZHw5Lbm9k45drDkgq2VNNA==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/template@^7.22.5", "@babel/template@^7.3.3":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.22.5.tgz#0c8c4d944509875849bd0344ff0050756eefc6ec"
@@ -1448,6 +1455,33 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.47.0.tgz#5478fdf443ff8158f9de171c704ae45308696c7d"
   integrity sha512-P6omY1zv5MItm93kLM8s2vr1HICJH8v0dvddDhysbIuZ+vcjOHg5Zbkf1mTkcmi2JA9oBG2anOkRnW8WJTS8Og==
 
+"@floating-ui/core@^1.4.2":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.5.0.tgz#5c05c60d5ae2d05101c3021c1a2a350ddc027f8c"
+  integrity sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==
+  dependencies:
+    "@floating-ui/utils" "^0.1.3"
+
+"@floating-ui/dom@^1.5.1":
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.5.3.tgz#54e50efcb432c06c23cd33de2b575102005436fa"
+  integrity sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==
+  dependencies:
+    "@floating-ui/core" "^1.4.2"
+    "@floating-ui/utils" "^0.1.3"
+
+"@floating-ui/react-dom@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-2.0.2.tgz#fab244d64db08e6bed7be4b5fcce65315ef44d20"
+  integrity sha512-5qhlDvjaLmAst/rKb3VdlCinwTF4EYMiVxuuc/HVUjs46W0zgtbMmAZ1UTsDrRTxRmUEzl92mOtWbeeXL26lSQ==
+  dependencies:
+    "@floating-ui/dom" "^1.5.1"
+
+"@floating-ui/utils@^0.1.3":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.1.4.tgz#19654d1026cc410975d46445180e70a5089b3e7d"
+  integrity sha512-qprfWkn82Iw821mcKofJ5Pk9wgioHicxcQMxx+5zt5GSKoqdWvgG5AxVmpmUUjzTLPVSH5auBrhI93Deayn/DA==
+
 "@humanwhocodes/config-array@^0.11.10":
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.10.tgz#5a3ffe32cc9306365fb3fd572596cd602d5e12d2"
@@ -1467,20 +1501,20 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@inseefr/lunatic-dsfr@0.0.31":
-  version "0.0.31"
-  resolved "https://registry.yarnpkg.com/@inseefr/lunatic-dsfr/-/lunatic-dsfr-0.0.31.tgz#2fe83f5118ca658c455879abfb8f70cb335f3116"
-  integrity sha512-JE9dXJ/8xhSDIuWv5VGMarzLgUWxsAc/DIWo/zwF4owSTNh63/12VU1TNgP8Q1tdJJ0SWkEXHGiJ7tEs0+flfg==
+"@inseefr/lunatic-dsfr@0.0.36":
+  version "0.0.36"
+  resolved "https://registry.yarnpkg.com/@inseefr/lunatic-dsfr/-/lunatic-dsfr-0.0.36.tgz#d5a2dde2eb37fcfa34310fa2bd8f36240a2e0a05"
+  integrity sha512-RthIIQkM3qOl+BYuwKC/LkpwIXbWDOYmsI7038dAugww8tzQaRn48uDIEkPh+NmpArlhGtg3zr9U3xDz+7DwNg==
   dependencies:
     "@emotion/styled" "^11.10.6"
-    "@inseefr/lunatic" "^2.5.2-beta"
+    "@inseefr/lunatic" "^2.6.0"
     "@mui/material" "^5.12.0"
     classnames "^2.3.2"
     react-number-format "^5.1.4"
     sass-loader "^13.2.0"
     tss-react "4.8.6"
 
-"@inseefr/lunatic@2.5.2-beta", "@inseefr/lunatic@^2.5.2-beta":
+"@inseefr/lunatic@2.5.2-beta":
   version "2.5.2-beta"
   resolved "https://registry.yarnpkg.com/@inseefr/lunatic/-/lunatic-2.5.2-beta.tgz#12680a41d2aa3e8bc68ff2f8a36d08d94fd50f3c"
   integrity sha512-+hxfp66PplG7DaD/Apnm0QHSb7UEakryWKRl6kqhTxx96+Ufve/eLeCZq87q7y/QD94og60YslgAUyet2tfmlA==
@@ -1504,10 +1538,44 @@
     snowball "^0.3.1"
     string-tokenizer "^0.0.8"
 
+"@inseefr/lunatic@^2.6.0":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@inseefr/lunatic/-/lunatic-2.6.1.tgz#00f71d1356fdc9e5807c6734dd8e02ceb61dc583"
+  integrity sha512-VT9nvz4tdcdg/CgD40srtBQfPmJtrvsh5v96xBDLrNR6pK4UGGFGBkp1mPbq8Y6ulNGcwiGSUCitXz0WvTBSlQ==
+  dependencies:
+    "@inseefr/trevas" "^0.1.20"
+    "@inseefr/vtl-2.0-antlr-tools" "^0.1.0-bundle"
+    antlr4 "4.11.0"
+    classnames "^2.3.1"
+    date-fns "^2.25.0"
+    lodash.camelcase "^4.3.0"
+    lodash.debounce "^4.0.8"
+    lodash.isequal "^4.5.0"
+    object-hash "^2.2.0"
+    prop-types "^15.7.2"
+    react-keyboard-event-handler "^1.5.4"
+    react-markdown "^8.0.3"
+    react-number-format "^5.1.3"
+    react-tooltip "^4.2.15"
+    remove-accents "^0.4.2"
+    sass "^1.58.3"
+    snowball "^0.3.1"
+    string-tokenizer "^0.0.8"
+
 "@inseefr/trevas@^0.1.19":
   version "0.1.19"
   resolved "https://registry.yarnpkg.com/@inseefr/trevas/-/trevas-0.1.19.tgz#5b0cf8d288afba4880ac15592cf80657dc8ade9d"
   integrity sha512-zvNw8JPf7jlgqznvnteEYTTnS3i0Lslb7y8EPs1OHYqsSyDiXwp9RG25oUSMK8A/y4kblkQO/cVDc971+H3RoA==
+  dependencies:
+    "@inseefr/vtl-2.0-antlr-tools" "0.1.0"
+    antlr4 "4.8.0"
+    data-forge "^1.8.8"
+    date-fns "^2.27.0"
+
+"@inseefr/trevas@^0.1.20":
+  version "0.1.20"
+  resolved "https://registry.yarnpkg.com/@inseefr/trevas/-/trevas-0.1.20.tgz#a1d68cf3d22a4da1ef99c1c8560470c8dda407d7"
+  integrity sha512-x1UotSHqHfGhut0JgPCLu+TXZtDpcYSrFQtlIl/L1kav6zYBa888AHhkADWB2hpJM/XAG3lQEfZrqgnsgbQK1g==
   dependencies:
     "@inseefr/vtl-2.0-antlr-tools" "0.1.0"
     antlr4 "4.8.0"
@@ -1840,12 +1908,30 @@
     prop-types "^15.8.1"
     react-is "^18.2.0"
 
+"@mui/base@5.0.0-beta.16":
+  version "5.0.0-beta.16"
+  resolved "https://registry.yarnpkg.com/@mui/base/-/base-5.0.0-beta.16.tgz#5869b8cc83ea5da0083bb11790bda007c2384564"
+  integrity sha512-OYxhC81c9bO0wobGcM8rrY5bRwpCXAI21BL0P2wz/2vTv4ek7ALz9+U5M8wgdmtRNUhmCmAB4L2WRwFRf5Cd8Q==
+  dependencies:
+    "@babel/runtime" "^7.22.15"
+    "@floating-ui/react-dom" "^2.0.2"
+    "@mui/types" "^7.2.4"
+    "@mui/utils" "^5.14.10"
+    "@popperjs/core" "^2.11.8"
+    clsx "^2.0.0"
+    prop-types "^15.8.1"
+
+"@mui/core-downloads-tracker@^5.14.10":
+  version "5.14.10"
+  resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.14.10.tgz#32a8581be98344bbda5ed31fc7b41788bd2e3bc5"
+  integrity sha512-kPHu/NhZq1k+vSZR5wq3AyUfD4bnfWAeuKpps0+8PS7ZHQ2Lyv1cXJh+PlFdCIOa0PK98rk3JPwMzS8BMhdHwQ==
+
 "@mui/core-downloads-tracker@^5.14.5":
   version "5.14.5"
   resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.14.5.tgz#c5854b89d57520c77253a79b20b784d5c2903fb6"
   integrity sha512-+wpGH1USwPcKMFPMvXqYPC6fEvhxM3FzxC8lyDiNK/imLyyJ6y2DPb1Oue7OGIKJWBmYBqrWWtfovrxd1aJHTA==
 
-"@mui/material@^5.11.8", "@mui/material@^5.12.0":
+"@mui/material@^5.11.8":
   version "5.14.5"
   resolved "https://registry.yarnpkg.com/@mui/material/-/material-5.14.5.tgz#4610b381fd159cd208c28e1d1f29c303ea24a518"
   integrity sha512-4qa4GMfuZH0Ai3mttk5ccXP8a3sf7aPlAJwyMrUSz6h9hPri6BPou94zeu3rENhhmKLby9S/W1y+pmficy8JKA==
@@ -1863,6 +1949,33 @@
     react-is "^18.2.0"
     react-transition-group "^4.4.5"
 
+"@mui/material@^5.12.0":
+  version "5.14.10"
+  resolved "https://registry.yarnpkg.com/@mui/material/-/material-5.14.10.tgz#b8c6ba17c25c0df54053cb0f1bb35083bc91dace"
+  integrity sha512-ejFMppnO+lzBXpzju+N4SSz0Mhmi5sihXUGcr5FxpgB6bfUP0Lpe32O0Sw/3s8xlmLEvG1fqVT0rRyAVMlCA+A==
+  dependencies:
+    "@babel/runtime" "^7.22.15"
+    "@mui/base" "5.0.0-beta.16"
+    "@mui/core-downloads-tracker" "^5.14.10"
+    "@mui/system" "^5.14.10"
+    "@mui/types" "^7.2.4"
+    "@mui/utils" "^5.14.10"
+    "@types/react-transition-group" "^4.4.6"
+    clsx "^2.0.0"
+    csstype "^3.1.2"
+    prop-types "^15.8.1"
+    react-is "^18.2.0"
+    react-transition-group "^4.4.5"
+
+"@mui/private-theming@^5.14.10":
+  version "5.14.10"
+  resolved "https://registry.yarnpkg.com/@mui/private-theming/-/private-theming-5.14.10.tgz#42b176b27435931aff40d50833413d10150ac007"
+  integrity sha512-f67xOj3H06wWDT9xBg7hVL/HSKNF+HG1Kx0Pm23skkbEqD2Ef2Lif64e5nPdmWVv+7cISCYtSuE2aeuzrZe78w==
+  dependencies:
+    "@babel/runtime" "^7.22.15"
+    "@mui/utils" "^5.14.10"
+    prop-types "^15.8.1"
+
 "@mui/private-theming@^5.14.5":
   version "5.14.5"
   resolved "https://registry.yarnpkg.com/@mui/private-theming/-/private-theming-5.14.5.tgz#834e1569c31e2644665f98d902def79014053017"
@@ -1879,6 +1992,30 @@
   dependencies:
     "@babel/runtime" "^7.21.0"
     "@emotion/cache" "^11.11.0"
+    csstype "^3.1.2"
+    prop-types "^15.8.1"
+
+"@mui/styled-engine@^5.14.10":
+  version "5.14.10"
+  resolved "https://registry.yarnpkg.com/@mui/styled-engine/-/styled-engine-5.14.10.tgz#2ec443031e48425cd6fda63be498cfa262c1d3a0"
+  integrity sha512-EJckxmQHrsBvDbFu1trJkvjNw/1R7jfNarnqPSnL+jEQawCkQIqVELWLrlOa611TFtxSJGkdUfCFXeJC203HVg==
+  dependencies:
+    "@babel/runtime" "^7.22.15"
+    "@emotion/cache" "^11.11.0"
+    csstype "^3.1.2"
+    prop-types "^15.8.1"
+
+"@mui/system@^5.14.10":
+  version "5.14.10"
+  resolved "https://registry.yarnpkg.com/@mui/system/-/system-5.14.10.tgz#b125f8370c1c92af04f1839c40e034d4edc4ad29"
+  integrity sha512-QQmtTG/R4gjmLiL5ECQ7kRxLKDm8aKKD7seGZfbINtRVJDyFhKChA1a+K2bfqIAaBo1EMDv+6FWNT1Q5cRKjFA==
+  dependencies:
+    "@babel/runtime" "^7.22.15"
+    "@mui/private-theming" "^5.14.10"
+    "@mui/styled-engine" "^5.14.10"
+    "@mui/types" "^7.2.4"
+    "@mui/utils" "^5.14.10"
+    clsx "^2.0.0"
     csstype "^3.1.2"
     prop-types "^15.8.1"
 
@@ -1900,6 +2037,16 @@
   version "7.2.4"
   resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.2.4.tgz#b6fade19323b754c5c6de679a38f068fd50b9328"
   integrity sha512-LBcwa8rN84bKF+f5sDyku42w1NTxaPgPyYKODsh01U1fVstTClbUoSA96oyRBnSNyEiAVjKm6Gwx9vjR+xyqHA==
+
+"@mui/utils@^5.14.10":
+  version "5.14.10"
+  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-5.14.10.tgz#4b0a2a26f1ee12323010daa9d7aecf3384acfc3c"
+  integrity sha512-Rn+vYQX7FxkcW0riDX/clNUwKuOJFH45HiULxwmpgnzQoQr3A0lb+QYwaZ+FAkZrR7qLoHKmLQlcItu6LT0y/Q==
+  dependencies:
+    "@babel/runtime" "^7.22.15"
+    "@types/prop-types" "^15.7.5"
+    prop-types "^15.8.1"
+    react-is "^18.2.0"
 
 "@mui/utils@^5.14.5":
   version "5.14.5"
@@ -8963,10 +9110,17 @@ react-markdown@^8.0.3:
     unist-util-visit "^4.0.0"
     vfile "^5.0.0"
 
-react-number-format@^5.1.3, react-number-format@^5.1.4:
+react-number-format@^5.1.3:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/react-number-format/-/react-number-format-5.3.0.tgz#46dfb9e96d7d85401ca62f399dff6769f4a56861"
   integrity sha512-3h5kuO5x9HpifEgCzvw6kDljzjsI3OhgnT/BRzZbzdbHVb755eVzJuNnRUZr3h/ATu3Sct9O+XrYc9HrAj/6bQ==
+  dependencies:
+    prop-types "^15.7.2"
+
+react-number-format@^5.1.4:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/react-number-format/-/react-number-format-5.3.1.tgz#840c257da9cb4b248990d8db46e4d23e8bac67ff"
+  integrity sha512-qpYcQLauIeEhCZUZY9jXZnnroOtdy3jYaS1zQ3M1Sr6r/KMOBEIGNIb7eKT19g2N1wbYgFgvDzs19hw5TrB8XQ==
   dependencies:
     prop-types "^15.7.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1514,31 +1514,7 @@
     sass-loader "^13.2.0"
     tss-react "4.8.6"
 
-"@inseefr/lunatic@2.5.2-beta":
-  version "2.5.2-beta"
-  resolved "https://registry.yarnpkg.com/@inseefr/lunatic/-/lunatic-2.5.2-beta.tgz#12680a41d2aa3e8bc68ff2f8a36d08d94fd50f3c"
-  integrity sha512-+hxfp66PplG7DaD/Apnm0QHSb7UEakryWKRl6kqhTxx96+Ufve/eLeCZq87q7y/QD94og60YslgAUyet2tfmlA==
-  dependencies:
-    "@inseefr/trevas" "^0.1.19"
-    "@inseefr/vtl-2.0-antlr-tools" "^0.1.0-bundle"
-    antlr4 "4.11.0"
-    classnames "^2.3.1"
-    date-fns "^2.25.0"
-    lodash.camelcase "^4.3.0"
-    lodash.debounce "^4.0.8"
-    lodash.isequal "^4.5.0"
-    object-hash "^2.2.0"
-    prop-types "^15.7.2"
-    react-keyboard-event-handler "^1.5.4"
-    react-markdown "^8.0.3"
-    react-number-format "^5.1.3"
-    react-tooltip "^4.2.15"
-    remove-accents "^0.4.2"
-    sass "^1.58.3"
-    snowball "^0.3.1"
-    string-tokenizer "^0.0.8"
-
-"@inseefr/lunatic@^2.6.0":
+"@inseefr/lunatic@2.6.1", "@inseefr/lunatic@^2.6.0":
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/@inseefr/lunatic/-/lunatic-2.6.1.tgz#00f71d1356fdc9e5807c6734dd8e02ceb61dc583"
   integrity sha512-VT9nvz4tdcdg/CgD40srtBQfPmJtrvsh5v96xBDLrNR6pK4UGGFGBkp1mPbq8Y6ulNGcwiGSUCitXz0WvTBSlQ==
@@ -1561,16 +1537,6 @@
     sass "^1.58.3"
     snowball "^0.3.1"
     string-tokenizer "^0.0.8"
-
-"@inseefr/trevas@^0.1.19":
-  version "0.1.19"
-  resolved "https://registry.yarnpkg.com/@inseefr/trevas/-/trevas-0.1.19.tgz#5b0cf8d288afba4880ac15592cf80657dc8ade9d"
-  integrity sha512-zvNw8JPf7jlgqznvnteEYTTnS3i0Lslb7y8EPs1OHYqsSyDiXwp9RG25oUSMK8A/y4kblkQO/cVDc971+H3RoA==
-  dependencies:
-    "@inseefr/vtl-2.0-antlr-tools" "0.1.0"
-    antlr4 "4.8.0"
-    data-forge "^1.8.8"
-    date-fns "^2.27.0"
 
 "@inseefr/trevas@^0.1.20":
   version "0.1.20"


### PR DESCRIPTION
When receiving an error 301, we need to be able to customise the error message using metadata.  The error message can also change depending on the type of 301 error returned by the API. 

Solution: 
Add another navigate function in LoadSourceData to handle the 301 response.  This function redirects to either `/301` by default or `/questionnaire/${SURVEY_NAME}/301/${ERROR_TYPE}` if there is a survey and errorType present. 

To avoid creating another Error component, I refactorised the component used for 404 so that it can handle the code 301. 

In order to access the customisable content in the metadata file, we wrap the error component with LoadFromApi similarly to the Optional.tsx component. 

As the error page doesn't use the <Layout/> component, unfortunately it is not possible to use the optional component, which has the same url format (`/questionnaire/${SURVEY_NAME}/${PAGE_NAME}`) 

In order to capture the errorType, we need to parse the error message returned from the API.  We are investigating whether we can include the errorType directly in the response header to eliminate this step. 

