### PR TITLE
listen handle change for controls

### DIFF
--- a/src/components/orchestrator/Controls.tsx
+++ b/src/components/orchestrator/Controls.tsx
@@ -1,8 +1,6 @@
 import { PropsWithChildren, useCallback, useEffect, useState } from 'react';
-
 import { LunaticError } from '../../typeLunatic/type';
 import { OrchestratedElement } from '../../typeStromae/type';
-
 import { CloneElements } from './CloneElements';
 
 export function Controls(props: PropsWithChildren<OrchestratedElement>) {
@@ -10,6 +8,7 @@ export function Controls(props: PropsWithChildren<OrchestratedElement>) {
 		useState<Record<string, Array<LunaticError>>>();
 	const [warning, setWarning] = useState<boolean>(false);
 	const [criticality, setCriticality] = useState<boolean>();
+
 	const {
 		children = [],
 		getErrors,
@@ -17,6 +16,8 @@ export function Controls(props: PropsWithChildren<OrchestratedElement>) {
 		goPreviousPage = () => null,
 		compileControls,
 		pageTag,
+		handleChangeCalled,
+		setHandleChangeCalled,
 		...rest
 	} = props;
 
@@ -34,8 +35,8 @@ export function Controls(props: PropsWithChildren<OrchestratedElement>) {
 		if (compileControls) {
 			errors = compileControls();
 		}
-
-		if (warning) {
+		setHandleChangeCalled?.(false);
+		if (warning && !handleChangeCalled) {
 			setWarning(false);
 			setCurrentErrors(undefined);
 			setCriticality(false);
@@ -51,7 +52,13 @@ export function Controls(props: PropsWithChildren<OrchestratedElement>) {
 		} else {
 			goNextPage();
 		}
-	}, [compileControls, goNextPage, warning]);
+	}, [
+		compileControls,
+		goNextPage,
+		warning,
+		handleChangeCalled,
+		setHandleChangeCalled,
+	]);
 
 	const handleGoPrevious: () => void = useCallback(() => {
 		setWarning(false);

--- a/src/components/orchestrator/UseLunatic.tsx
+++ b/src/components/orchestrator/UseLunatic.tsx
@@ -41,9 +41,11 @@ export function UseLunatic(props: PropsWithChildren<OrchestratorProps>) {
 	const { data, stateData, personalization = [] } = surveyUnitData ?? {};
 	const { currentPage: pageFromAPI, state } = stateData ?? {};
 	const [currentChange, setCurrentChange] = useState<{ name: string }>();
+	const [handleChangeCalled, setHandleChangeCalled] = useState(false);
 
 	const onChange = useCallback(({ name }: { name: string }, value: unknown) => {
 		setCurrentChange({ name });
+		setHandleChangeCalled(true);
 	}, []);
 
 	useEffect(() => {
@@ -120,6 +122,8 @@ export function UseLunatic(props: PropsWithChildren<OrchestratorProps>) {
 				pageFromAPI={pageFromAPI}
 				personalization={personalizationMap}
 				collectStatus={collectStatus}
+				handleChangeCalled={handleChangeCalled}
+				setHandleChangeCalled={setHandleChangeCalled}
 			>
 				{children}
 			</CloneElements>

--- a/src/typeStromae/type.ts
+++ b/src/typeStromae/type.ts
@@ -72,6 +72,7 @@ export type OrchestratedElement = {
 	// controls errors
 	currentErrors?: Record<string, Array<LunaticError>>;
 	criticality?: boolean;
+	handleChangeCalled?: boolean;
 	// handleChange
 	currentChange?: { name: string };
 	// saving
@@ -86,6 +87,7 @@ export type OrchestratedElement = {
 	only?: string[];
 	except?: string[];
 	title?: string;
+	setHandleChangeCalled?: (value: boolean) => void;
 };
 
 export type QuestionnaireParams = {


### PR DESCRIPTION
Lorsque l'utilisateur modifie un champ quand sa page affiche des warnings, les contrôles doivent être revalider et non sortir directement vers la page suivante.