### PR TITLE
redirect when status VALIDATED on deconnexion

### DIFF
--- a/src/components/Header/HeaderAuth.tsx
+++ b/src/components/Header/HeaderAuth.tsx
@@ -1,39 +1,58 @@
 import { useCallback } from 'react';
 import { useParams } from 'react-router';
-
 import { useOidc } from '../../lib/oidc';
 import { CloneElements } from '../orchestrator/CloneElements';
-
 import { HeaderProps } from './Header';
+import {
+	uriSurveyUnit,
+	uriSurvey,
+	uri404,
+	uriDeconnexion,
+} from '../../lib/domainUri';
+import { CollectStatusEnum } from '../../typeStromae/type';
 
 type HeaderAuthProps = {
 	children: JSX.Element;
+	collectStatus?: CollectStatusEnum | null;
 };
 
 function getCallBack(args: { survey?: string; unit?: string }) {
 	const { survey, unit } = args;
 	if (survey && unit) {
-		return `${window.origin}/questionnaire/${survey}/unite-enquetee/${unit}`;
+		return uriSurveyUnit(survey, unit);
 	}
 	if (survey) {
-		return `${window.origin}/questionnaire/${survey}`;
+		return uriSurvey(survey);
 	}
-	return `${window.origin}/404`;
+	return uri404();
 }
 
-export function HeaderAuth({ children }: HeaderAuthProps) {
+function getLogOutUri(args: {
+	survey?: string;
+	unit?: string;
+	collectStatus?: CollectStatusEnum | null;
+}) {
+	const { survey, unit, collectStatus } = args;
+	if (collectStatus === CollectStatusEnum.Validated && survey) {
+		return uriSurvey(survey);
+	}
+	if (survey && unit) {
+		return uriDeconnexion(survey, unit);
+	}
+	return uri404();
+}
+
+export function HeaderAuth({ children, collectStatus }: HeaderAuthProps) {
 	const { login, logout, isAuthenticated } = useOidc();
 	const { survey, unit } = useParams();
 
 	const handleOidcAuth = useCallback(() => {
 		if (isAuthenticated) {
-			logout(
-				`${window.origin}/questionnaire/${survey}/unite-enquetee/${unit}/deconnexion`
-			);
+			logout(getLogOutUri({ survey, unit, collectStatus }));
 		} else {
 			login(getCallBack({ survey, unit }));
 		}
-	}, [isAuthenticated, login, logout, survey, unit]);
+	}, [isAuthenticated, login, logout, survey, unit, collectStatus]);
 
 	return (
 		<CloneElements<HeaderProps>

--- a/src/components/Welcome/WelcomeQuestions.tsx
+++ b/src/components/Welcome/WelcomeQuestions.tsx
@@ -61,7 +61,7 @@ export function WelcomeQuestions(props: { welcome: WelcomeType }) {
 					{props.welcome.Enq_MinistereTutelle}, valable pour l'année{' '}
 					{props.welcome.Enq_AnneeVisa} - Arrêté en{' '}
 					{props.welcome.Enq_ParutionJo
-						? `en date du ${props.welcome.Enq_DateParutionJo}`
+						? `date du ${props.welcome.Enq_DateParutionJo}`
 						: 'cours de parution'}
 					.
 				</p>

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -10,6 +10,7 @@ import { Footer } from '../footer/Footer';
 import { Layout as LayoutSkeleton } from '../skeleton/Layout';
 import { Main } from './Main';
 import { Display } from '@codegouvfr/react-dsfr/Display';
+import { CollectStatusEnum } from '../../typeStromae/type';
 
 type LayoutProps = {};
 
@@ -24,7 +25,9 @@ export function Layout({ children, ...rest }: PropsWithChildren<LayoutProps>) {
 	const alreadyLoad = useRef(false);
 	const [header, setHeader] = useState<HeaderType | undefined>(undefined);
 	const [footer, setFooter] = useState<FooterType | undefined>(undefined);
-	const { getMetadata } = useContext(loadSourceDataContext);
+	const [collectStatus, setCollectStatus] =
+		useState<CollectStatusEnum | null>();
+	const { getMetadata, getSurveyUnitData } = useContext(loadSourceDataContext);
 
 	useAsyncEffect(async () => {
 		if (!getMetadata || alreadyLoad.current) {
@@ -39,6 +42,11 @@ export function Layout({ children, ...rest }: PropsWithChildren<LayoutProps>) {
 		} else throw new Error('metadata missing.');
 	}, [getMetadata, alreadyLoad]);
 
+	useAsyncEffect(async () => {
+		const suData = await getSurveyUnitData?.();
+		setCollectStatus(suData?.stateData?.state);
+	}, [getSurveyUnitData]);
+
 	if (!header || !footer) {
 		return <LayoutSkeleton />;
 	}
@@ -46,7 +54,7 @@ export function Layout({ children, ...rest }: PropsWithChildren<LayoutProps>) {
 	return (
 		<>
 			<SkipLinks links={defaultLinks} />
-			<HeaderAuth>
+			<HeaderAuth collectStatus={collectStatus}>
 				<Header header={header} />
 			</HeaderAuth>
 			<Main id="contenu">{children}</Main>

--- a/src/lib/domainUri/uri.ts
+++ b/src/lib/domainUri/uri.ts
@@ -33,6 +33,15 @@ export function uriSurveyUnit(survey?: string, unit?: string) {
 	return uri404();
 }
 
+/**
+ * Page publique, spécifique à l'enquête.
+ * @param survey
+ * @returns
+ */
+export function uriSurvey(survey: string) {
+	return `/questionnaire/${survey}`;
+}
+
 /*
  * ressource invoquée par l'utilisateur pour finaliser le questionnaire.
  */
@@ -41,4 +50,14 @@ export function uriPostEnvoi(survey?: string, unit?: string) {
 		return `/questionnaire/${survey}/unite-enquetee/${unit}/post-envoi`;
 	}
 	return uri404();
+}
+
+/**
+ * Page de déconnexion.
+ * @param survey
+ * @param unit
+ * @returns
+ */
+export function uriDeconnexion(survey: string, unit: string) {
+	return `/questionnaire/${survey}/unite-enquetee/${unit}/deconnexion`;
 }

--- a/src/lib/surveys/getSurveyUnit.ts
+++ b/src/lib/surveys/getSurveyUnit.ts
@@ -1,11 +1,11 @@
+import moize from 'moize';
 import type { SurveyUnitData } from '../../typeStromae/type';
 import { authenticatedGetRequest } from '../commons/axios-utils';
 
 import { surveyUnit } from './api';
 
-export const getSurveyUnitData =
-	(BASE_URL: string) =>
-	async (unit: string, token: string): Promise<SurveyUnitData> => {
+export const getSurveyUnitData = (BASE_URL: string) =>
+	moize(async (unit: string, token: string): Promise<SurveyUnitData> => {
 		const { data, stateData, personalization } =
 			await authenticatedGetRequest<SurveyUnitData>(
 				surveyUnit(BASE_URL, unit),
@@ -13,4 +13,4 @@ export const getSurveyUnitData =
 			);
 
 		return { data, stateData, personalization };
-	};
+	});


### PR DESCRIPTION
Lorsque l'utilisateur se déconnecte, après transmis ses données, on l'envoi directement sur la page /questionnaire/idQuestionnaire
Toute les url de redirection sont relatives, ça ne devrait pas poser de problème ?
J'ai ajouté moize sur getSuData, pour ne pas multiplier les appels à à getSudata
