### PR TITLE
refactor use lunatic components

### DIFF
--- a/src/components/formulaire/Formulaire.tsx
+++ b/src/components/formulaire/Formulaire.tsx
@@ -5,7 +5,7 @@ import { Form } from '../skeleton/Form';
 
 type Props = Pick<
 	OrchestratedElement,
-	'currentErrors' | 'disabled' | 'getComponents' | 'waiting'
+	'currentErrors' | 'disabled' | 'getComponents' | 'waiting' | 'pageTag'
 >;
 
 const useStyles = makeStyles()({
@@ -17,7 +17,13 @@ const useStyles = makeStyles()({
 });
 
 export function Formulaire(props: Props) {
-	const { getComponents, currentErrors, disabled = false, waiting } = props;
+	const {
+		getComponents,
+		currentErrors,
+		disabled = false,
+		waiting,
+		pageTag,
+	} = props;
 	const { classes, cx } = useStyles();
 	if (waiting) {
 		return <Form />;
@@ -25,6 +31,7 @@ export function Formulaire(props: Props) {
 	return (
 		<form id="stromae-form" className={cx(classes.root)}>
 			<ComponentsRenderer
+				focusKey={pageTag}
 				getComponents={getComponents}
 				currentErrors={currentErrors}
 				disabled={disabled}

--- a/src/components/orchestrator/Controls.tsx
+++ b/src/components/orchestrator/Controls.tsx
@@ -74,6 +74,7 @@ export function Controls(props: PropsWithChildren<OrchestratedElement>) {
 			goPreviousPage={handleGoPrevious}
 			criticality={criticality}
 			currentErrors={currentErrors}
+			pageTag={pageTag}
 		>
 			{children}
 		</CloneElements>


### PR DESCRIPTION
Lunatic 2.6 comes with a new component that handle rendering a list of component while adding a control for autofocus. I used the error length + pageTag to know when to refocus but I'm not sure it's the best way to achieve the goal.