### PR TITLE
V2: fix visu with auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stromae",
-  "version": "2.4.14",
+  "version": "2.4.15",
   "description": "Web application for the management of questionnaires powered by Lunatic",
   "repository": {
     "type": "git",

--- a/src/utils/hooks/api.js
+++ b/src/utils/hooks/api.js
@@ -29,7 +29,7 @@ export const useGetReferentiel = (nomenclatures) => {
   const getReferentielForVizu = useConstCallback((refName) => {
     if (nomenclatures && Object.keys(nomenclatures).includes(refName)) {
       const finalUrl = nomenclatures[refName];
-      return getFetcherForLunatic(oidc.getTokens().accessToken)(finalUrl);
+      return getFetcherForLunatic(null)(finalUrl);
     }
     // No nomenclature, return empty array to lunatic
     return Promise.resolve([]);


### PR DESCRIPTION
Fix: #519 

Quand on est en mode "oidc" et qu'on est sur une route "non-protégée", la fonction `getTokens` fournie par la lib `oidc-spa` n'existe pas et provoque une erreur en essayant de l'appelée.

On remplace le token par `null` car il s'agit de la fonction permettant de récupérer les nomenclatures en visualisation seulement.