### PR TITLE
save on click on last page

### DIFF
--- a/src/components/orchestrator/UseLunatic.tsx
+++ b/src/components/orchestrator/UseLunatic.tsx
@@ -132,9 +132,13 @@ export function UseLunatic(props: PropsWithChildren<OrchestratorProps>) {
 		previousPageTag !== pageTag;
 
 	const handleGoNext = useCallback(() => {
-		shouldSync.current = true;
-		goNextPage?.();
-	}, [goNextPage]);
+		if (isLastPage) {
+			saveChange({ pageTag, getData });
+		} else {
+			shouldSync.current = true;
+			goNextPage?.();
+		}
+	}, [goNextPage, isLastPage, saveChange, pageTag, getData]);
 
 	const handleGoBack = useCallback(() => {
 		shouldSync.current = true;


### PR DESCRIPTION
normalement, on ne sauvegarde que lorsque l'on arrive sur la page suivante, ce qui pose un problème lorsque l'on quitte la dernière page. On force donc une dernière sauvegarde sur la dernière page, au cas où.