### PR TITLE
V3/remove declarations after

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "stromae",
-	"version": "3.0.6",
+	"version": "3.0.7",
 	"private": true,
 	"dependencies": {
 		"@axa-fr/react-oidc": "6.14.0",

--- a/src/components/ContinueOrRestart/WarningVisu.tsx
+++ b/src/components/ContinueOrRestart/WarningVisu.tsx
@@ -25,8 +25,8 @@ export function ModalWarningVizu() {
 				Bienvenue
 			</h1>
 			<p>
-				Vous visualisez actuellement votre questionnaire sur une plateforme
-				"beta".
+				Vous visualisez actuellement votre questionnaire sur un orchestrateur en
+				version "beta".
 			</p>
 
 			<section className={fr.cx('fr-accordion')}>

--- a/src/components/ContinueOrRestart/WarningVisu.tsx
+++ b/src/components/ContinueOrRestart/WarningVisu.tsx
@@ -1,0 +1,66 @@
+import { fr } from '@codegouvfr/react-dsfr/fr';
+import { useRef, useState } from 'react';
+import { ModalDsfr } from './ModalDsfr';
+
+export function ModalWarningVizu() {
+	const last = useRef<HTMLButtonElement>(null);
+
+	const [display, setDisplay] = useState(true);
+
+	function onClose() {
+		setDisplay(false);
+	}
+
+	if (!display) {
+		return null;
+	}
+
+	return (
+		<ModalDsfr
+			id="start-or-continue"
+			close={onClose}
+			last={last.current as HTMLElement}
+		>
+			<h1 className={fr.cx('fr-modal__title')} id="fr-modal-title-modal-1">
+				Bienvenue
+			</h1>
+			<p>
+				Vous visualisez actuellement votre questionnaire sur une plateforme
+				"beta".
+			</p>
+
+			<section className={fr.cx('fr-accordion')}>
+				<h3 className={fr.cx('fr-accordion__title')}>
+					<button
+						className={fr.cx('fr-accordion__btn')}
+						aria-expanded="false"
+						aria-controls="accordion-106"
+					>
+						En savoir plus
+					</button>
+				</h3>
+				<div className={fr.cx('fr-collapse')} id="accordion-106">
+					<p>
+						Pour des raisons techniques, certaines fonctionnalités, comme les
+						déclarations après le libellé des questions ont été désactivées.
+					</p>
+					<p>
+						Ces fonctionnalités sont en cours de révision par l'atelier de
+						conception, elles reviendront prochainement.
+					</p>
+				</div>
+			</section>
+			<br />
+
+			<p>Merci de votre compréhension.</p>
+
+			<ul className={fr.cx('fr-btns-group', 'fr-btns-group--inline-md')}>
+				<li>
+					<button className={fr.cx('fr-btn')} onClick={onClose} ref={last}>
+						J'ai compris
+					</button>
+				</li>
+			</ul>
+		</ModalDsfr>
+	);
+}

--- a/src/components/orchestrator/LoadSourceData.tsx
+++ b/src/components/orchestrator/LoadSourceData.tsx
@@ -5,10 +5,11 @@ import { LunaticSource } from '../../typeLunatic/type-source';
 import { MetadataSurvey, SurveyUnitData } from '../../typeStromae/type';
 import { loadSourceDataContext } from '../loadSourceData/LoadSourceDataContext';
 
+import { uri301, uri404 } from '../../lib/domainUri';
+import { removeDeclarationsAfterFromSource } from '../../utils/questionnaire';
 import { CloneElements } from './CloneElements';
 import { OrchestratorProps } from './Orchestrator';
 import { useRemote } from './useRemote';
-import { uri301, uri404 } from '../../lib/domainUri';
 
 type LoadSourceDataProps = {
 	onChange?: (args: any) => void;
@@ -45,13 +46,16 @@ export function LoadSourceData({
 		navigateError
 	);
 
-	if (!source || !surveyUnitData) {
+	const sourceWithoutDeclarationsAfter =
+		removeDeclarationsAfterFromSource(source);
+
+	if (!sourceWithoutDeclarationsAfter || !surveyUnitData) {
 		// TODO skeleton
 		return null;
 	}
 	return (
 		<CloneElements<OrchestratorProps>
-			source={source}
+			source={sourceWithoutDeclarationsAfter}
 			surveyUnitData={surveyUnitData}
 			getReferentiel={getReferentiel}
 			onChange={onChange}

--- a/src/pages/visualize/VisualizeResources.tsx
+++ b/src/pages/visualize/VisualizeResources.tsx
@@ -1,6 +1,7 @@
 import { AlertesSaving } from '../../components/AlertSaving/AlertesSaving';
 import { ComplementaryComponents } from '../../components/ComplementaryComponents';
 import { ContinueOrRestart } from '../../components/ContinueOrRestart/ContinueOrRestart';
+import { ModalWarningVizu } from '../../components/ContinueOrRestart/WarningVisu';
 import { DraftBanner } from '../../components/DraftBanner/DraftBanner';
 import { Grid } from '../../components/Grid/Grid';
 import { Formulaire } from '../../components/formulaire';
@@ -43,6 +44,7 @@ export function VisualizeResources(props: VisualizeResourcesProps) {
 						<AlertesSaving />
 						<Formulaire />
 						<Modals />
+						<ModalWarningVizu />
 						<Continuer />
 					</Grid>
 					<ComplementaryComponents />

--- a/src/utils/questionnaire/index.ts
+++ b/src/utils/questionnaire/index.ts
@@ -1,7 +1,7 @@
 import { LunaticComponentDefinition } from '../../typeLunatic/type';
 import { DeclarationType, LunaticSource } from '../../typeLunatic/type-source';
 
-const removeDeclartionsAfterFromDeclarations = (
+const removeDeclarationsAfterFromDeclarations = (
 	declarations: DeclarationType[]
 ): DeclarationType[] => {
 	if (Array.isArray(declarations))
@@ -27,7 +27,7 @@ const removeDeclarationsAfterFromComponent = (
 		return component;
 	}
 
-	const declarationsWithoutAfter = removeDeclartionsAfterFromDeclarations(
+	const declarationsWithoutAfter = removeDeclarationsAfterFromDeclarations(
 		component.declarations
 	);
 

--- a/src/utils/questionnaire/index.ts
+++ b/src/utils/questionnaire/index.ts
@@ -1,0 +1,71 @@
+import { LunaticComponentDefinition } from '../../typeLunatic/type';
+import { DeclarationType, LunaticSource } from '../../typeLunatic/type-source';
+
+const removeDeclartionsAfterFromDeclarations = (
+	declarations: DeclarationType[]
+): DeclarationType[] => {
+	if (Array.isArray(declarations))
+		return declarations.filter(
+			({ position }) => position !== 'AFTER_QUESTION_TEXT'
+		);
+	return [];
+};
+
+/**
+ * Remove declarations with position AFTER_QUESTION_TEXT from component
+ * @param component
+ * @returns
+ */
+const removeDeclarationsAfterFromComponent = (
+	component: LunaticComponentDefinition
+): LunaticComponentDefinition => {
+	// We keep declarations AFTER_QUESTION_TEXT for Sequence and Subsequence
+	if (
+		component.componentType === 'Sequence' ||
+		component.componentType === 'Subsequence'
+	) {
+		return component;
+	}
+
+	const declarationsWithoutAfter = removeDeclartionsAfterFromDeclarations(
+		component.declarations
+	);
+
+	// For components which includes components like Loop
+	if ('components' in component) {
+		const newComponents = component.components.map(
+			removeDeclarationsAfterFromComponent
+		);
+		return {
+			...component,
+			declarations: declarationsWithoutAfter,
+			components: newComponents,
+		};
+	}
+
+	return {
+		...component,
+		declarations: declarationsWithoutAfter,
+	};
+};
+
+/**
+ * This function remove declarations AFTER_QUESTION_TEXT because they are not actually supported by Lunatic-DSFR.
+ * Only Sequence and Subsequence works fine.
+ * @param source
+ * @returns the source without declarations AFTER_QUESTION_TEXT inside component (except for Sequence and Subsequence component)
+ */
+export const removeDeclarationsAfterFromSource = (
+	source?: LunaticSource
+): LunaticSource | undefined => {
+	if (source && Array.isArray(source.components)) {
+		const componentsWithoutDeclartionsAfter = source.components.map(
+			removeDeclarationsAfterFromComponent
+		);
+		return {
+			...source,
+			components: componentsWithoutDeclartionsAfter,
+		};
+	}
+	return source;
+};


### PR DESCRIPTION
- remove declarations after to avoid app crash
- Adding modal for visu only

This PR doesn't affect RP questionnaire, because the rp's questionnaire doesn't use declarations with position `AFTER_QUESTION_TEXT`