### PR TITLE
descriptions or declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "stromae",
-	"version": "3.1.4",
+	"version": "3.1.5",
 	"private": true,
 	"dependencies": {
 		"@axa-fr/react-oidc": "^7.18.5",

--- a/src/typeLunatic/type-source.ts
+++ b/src/typeLunatic/type-source.ts
@@ -86,7 +86,7 @@ export type Hierarchy = {
 
 export type ComponentTypeBase = {
 	label: LabelType;
-	declarations: DeclarationType[];
+	declarations?: DeclarationType[];
 	conditionFilter: ConditionFilterType;
 	controls?: ControlType[];
 	id: string;

--- a/src/utils/questionnaire/index.ts
+++ b/src/utils/questionnaire/index.ts
@@ -2,7 +2,7 @@ import { LunaticComponentDefinition } from '../../typeLunatic/type';
 import { DeclarationType, LunaticSource } from '../../typeLunatic/type-source';
 
 const removeDeclarationsAfterFromDeclarations = (
-	declarations: DeclarationType[]
+	declarations?: DeclarationType[]
 ): DeclarationType[] => {
 	if (Array.isArray(declarations))
 		return declarations.filter(
@@ -10,6 +10,14 @@ const removeDeclarationsAfterFromDeclarations = (
 		);
 	return [];
 };
+
+function clearDeclarations(component: LunaticComponentDefinition) {
+	const { declarations, ...rest } = component;
+	if (declarations && declarations.length) {
+		return component;
+	}
+	return rest;
+}
 
 /**
  * Remove declarations with position AFTER_QUESTION_TEXT from component
@@ -28,7 +36,7 @@ const removeDeclarationsAfterFromComponent = (
 	}
 
 	const declarationsWithoutAfter = removeDeclarationsAfterFromDeclarations(
-		component.declarations
+		component?.declarations
 	);
 
 	// For components which includes components like Loop
@@ -36,17 +44,17 @@ const removeDeclarationsAfterFromComponent = (
 		const newComponents = component.components.map(
 			removeDeclarationsAfterFromComponent
 		);
-		return {
+		return clearDeclarations({
 			...component,
 			declarations: declarationsWithoutAfter,
 			components: newComponents,
-		};
+		});
 	}
 
-	return {
+	return clearDeclarations({
 		...component,
 		declarations: declarationsWithoutAfter,
-	};
+	});
 };
 
 /**


### PR DESCRIPTION
les descriptions ne s'affiche pas lorsque l'attributs déclarations est présent dans le component. Il faut l'effacer lorsque declarations est undefined ou vide.
Il faudrait revoir le processus de gestion des declaration/description dans les librairies en amont.
En attendant, on peut patcher comme cela.