### PR TITLE
variabiliser le nom de la preuve de dépôt

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 GENERATE_SOURCEMAP=false
 SKIP_PREFLIGHT_CHECK=true
-REACT_APP_SURVEY_API_BASE_URL=https://api-questionnaire-recensement.developpement6.insee.fr
+REACT_APP_SURVEY_API_BASE_URL=
 REACT_APP_LUNATIC_LOADER_WORKER_PATH=/workers/lunatic-append-worker-0.3.0-experimental.js
 REACT_APP_LUNATIC_SEARCH_WORKER_PATH=/workers/lunatic-searching-worker-0.3.0-experimental.js
 REACT_APP_LUNATIC_LABEL_WORKER_PATH=/workers/lunatic-label-worker-0.3.0-experimental.js
@@ -8,6 +8,7 @@ REACT_APP_SAVING_TIME=page
 REACT_APP_SAVING_STRATEGY=partial
 REACT_APP_DEFAULT_SURVEY=recensement
 REACT_APP_AUTH_TYPE=
+REACT_APP_DEPOSIT_PROOF_FILE_NAME=deposit-proof
 # REACT_APP_AUTH_TYPE: oidc / none, default oidc
 REACT_APP_DEBUG=
 REACT_APP_VISUALIZE_ENABLED=

--- a/src/components/postSubmit/PostSubmitSurvey.tsx
+++ b/src/components/postSubmit/PostSubmitSurvey.tsx
@@ -10,6 +10,9 @@ import Confirmation from '@codegouvfr/react-dsfr/dsfr/artwork/pictograms/system/
 import AdditionalInformation from './AdditionalInformation';
 import { MetadataSurvey, SurveyUnitData } from '../../typeStromae/type';
 import { uri404 } from '../../lib/domainUri';
+import { environment } from '../../utils/read-env-vars';
+
+const { DEPOSIT_PROOF_FILE_NAME } = environment;
 
 function parseDate(date?: number) {
 	if (date !== undefined) {
@@ -25,7 +28,7 @@ function download(data: BlobPart, unit: string) {
 	const url = URL.createObjectURL(new Blob([data]));
 	const aLink = document.createElement('a');
 	aLink.href = url;
-	aLink.download = `deposit-proof-${unit}.pdf`;
+	aLink.download = `${DEPOSIT_PROOF_FILE_NAME}-${unit}.pdf`;
 	aLink.click();
 }
 

--- a/src/utils/read-env-vars.ts
+++ b/src/utils/read-env-vars.ts
@@ -39,4 +39,6 @@ export const environment = {
 	// VISUALIZE is disabled by default, so if value is not present and not set to true in env-config.js, VISUALIZE page is disabled
 	VISUALIZE_ENABLED: `${getEnvVar('REACT_APP_VISUALIZE_ENABLED')}` === 'true',
 	DEBUG: Boolean(getEnvVar('REACT_APP_DEBUG') === 'true'),
+	DEPOSIT_PROOF_FILE_NAME:
+		getEnvVar('REACT_APP_DEPOSIT_PROOF_FILE_NAME') || 'deposit-proof',
 };


### PR DESCRIPTION
Pour permettre de changer le nom du fichier de preuve de dépôt lors du téléchargement