### PR TITLE
Fix/moize on last page

### DIFF
--- a/src/components/DraftBanner/DraftBanner.tsx
+++ b/src/components/DraftBanner/DraftBanner.tsx
@@ -51,7 +51,7 @@ function dependenciesHaveChanged(
 export function DraftBanner(props: PropsWithChildren<OrchestratedElement>) {
 	const { savingFailure, currentChange, personalization } = props;
 	const { classes, cx } = useStyles();
-	// saved is used as a flag to display the save message 
+	// saved is used as a flag to display the save message
 	const [saved, setSaved] = useState(false);
 	const [label, setlabel] = useState(personalization?.bannerLabel ?? '');
 	const bannerLabelDependencies = personalization?.bannerLabelDependencies
@@ -120,7 +120,11 @@ export function DraftBanner(props: PropsWithChildren<OrchestratedElement>) {
 					<div
 						className={cx(
 							classes.addressRow,
-							fr.cx('fr-grid-row--no-gutters', 'fr-grid-row', 'fr-grid-row--middle')
+							fr.cx(
+								'fr-grid-row--no-gutters',
+								'fr-grid-row',
+								'fr-grid-row--middle'
+							)
 						)}
 					>
 						<div
@@ -135,21 +139,20 @@ export function DraftBanner(props: PropsWithChildren<OrchestratedElement>) {
 								)
 							)}
 						>
-						{saved ? 	
-						
-						<Tag iconId="fr-icon-refresh-line">
-Enregistrement...
-</Tag>
-						: 						<Tag iconId="fr-icon-checkbox-circle-line">
-Brouillon enregistré
-</Tag> }
+							{saved ? (
+								<Tag iconId="fr-icon-refresh-line">Enregistrement...</Tag>
+							) : (
+								<Tag iconId="fr-icon-checkbox-circle-line">
+									Brouillon enregistré
+								</Tag>
+							)}
 						</div>
 						<BannerAddress label={computedLabel as string} />
 					</div>
-							<p className={fr.cx('fr-col-12', 'fr-col-md-10', 'fr-mb-0')}>
-			Vos réponses sont enregistrées automatiquement à chaque chargement de
-			page.
-		</p>
+					<p className={fr.cx('fr-col-12', 'fr-col-md-10', 'fr-mb-0')}>
+						Vos réponses sont enregistrées automatiquement à chaque chargement
+						de page.
+					</p>
 				</div>
 			</div>
 		</div>

--- a/src/components/loadSourceData/LoadFromApi.tsx
+++ b/src/components/loadSourceData/LoadFromApi.tsx
@@ -2,7 +2,6 @@ import { PropsWithChildren, useCallback, useMemo } from 'react';
 import { useAccessToken } from '../../lib/oidc';
 import { surveyApi } from '../../lib/surveys/surveysApi';
 import { DataVariables, StateData } from '../../typeStromae/type';
-
 import { AuthTypeEnum, environment } from '../../utils/read-env-vars';
 import { loadSourceDataContext } from './LoadSourceDataContext';
 
@@ -36,12 +35,19 @@ export function LoadFromApi({
 		return undefined;
 	}, [survey, isTokenReady, accessToken]);
 
-	const getSurveyUnitData = useCallback(async () => {
-		if (unit && isTokenReady) {
-			return surveyApi.getSurveyUnitData(unit, accessToken);
-		}
-		return undefined;
-	}, [unit, isTokenReady, accessToken]);
+	const getSurveyUnitData = useCallback(
+		async (refresh?: boolean) => {
+			if (unit && isTokenReady) {
+				if (refresh) {
+					return surveyApi.getFreshSurveyUnitData(unit, accessToken);
+				}
+
+				return surveyApi.getSurveyUnitData(unit, accessToken);
+			}
+			return undefined;
+		},
+		[unit, isTokenReady, accessToken]
+	);
 
 	const getReferentiel = useCallback(
 		async (name: string) => {

--- a/src/components/loadSourceData/LoadSourceDataContext.ts
+++ b/src/components/loadSourceData/LoadSourceDataContext.ts
@@ -10,7 +10,9 @@ import {
 export type LoadSourceDataContextType = {
 	getMetadata: () => Promise<MetadataSurvey | undefined>;
 	getSurvey: () => Promise<LunaticSource | undefined>;
-	getSurveyUnitData?: () => Promise<SurveyUnitData | undefined>;
+	getSurveyUnitData?: (
+		refresh?: boolean
+	) => Promise<SurveyUnitData | undefined>;
 	getReferentiel: (name: string) => Promise<Array<unknown>>;
 	/* */
 	putSurveyUnitData: (data?: DataVariables) => Promise<boolean>;

--- a/src/components/orchestrator/Controls.tsx
+++ b/src/components/orchestrator/Controls.tsx
@@ -34,6 +34,7 @@ export function Controls(props: PropsWithChildren<OrchestratedElement>) {
 		let errors;
 		if (compileControls) {
 			errors = compileControls();
+			console.log({ errors });
 		}
 		setRefreshControls?.(false);
 		if (warning && !refreshControls) {

--- a/src/components/postSubmit/PostSubmitSurvey.tsx
+++ b/src/components/postSubmit/PostSubmitSurvey.tsx
@@ -35,7 +35,7 @@ function download(data: BlobPart, unit: string) {
 export function PostSubmitSurvey() {
 	const navigate = useNavigate();
 	const { unit } = useParams();
-	const { getMetadata, getSurveyUnitData, getDepositProof } = useContext(
+	const { getMetadata, getDepositProof, getSurveyUnitData } = useContext(
 		loadSourceDataContext
 	);
 
@@ -52,7 +52,7 @@ export function PostSubmitSurvey() {
 
 	const metadata = useRemote<MetadataSurvey>(getMetadata, navigateError);
 	const surveyUnitData = useRemote<SurveyUnitData>(
-		getSurveyUnitData,
+		async () => getSurveyUnitData?.(true),
 		navigateError
 	);
 	const submit = metadata?.Submit;

--- a/src/lib/surveys/getSurveyUnit.ts
+++ b/src/lib/surveys/getSurveyUnit.ts
@@ -1,8 +1,9 @@
 import type { SurveyUnitData } from '../../typeStromae/type';
 import { authenticatedGetRequest } from '../commons/axios-utils';
+import moize from 'moize';
 import { surveyUnit } from './api';
 
-export const getSurveyUnitData =
+export const fectchSurveyUnitData =
 	(BASE_URL: string) =>
 	async (unit: string, token?: string): Promise<SurveyUnitData> => {
 		const { data, stateData, personalization } =
@@ -13,3 +14,8 @@ export const getSurveyUnitData =
 
 		return { data, stateData, personalization };
 	};
+
+export const getSurveyUnitData = (BASE_URL: string) =>
+	moize(fectchSurveyUnitData(BASE_URL), {
+		isPromise: true,
+	});

--- a/src/lib/surveys/getSurveyUnit.ts
+++ b/src/lib/surveys/getSurveyUnit.ts
@@ -1,18 +1,15 @@
 import type { SurveyUnitData } from '../../typeStromae/type';
 import { authenticatedGetRequest } from '../commons/axios-utils';
-import moize from 'moize';
 import { surveyUnit } from './api';
 
-export const getSurveyUnitData = (BASE_URL: string) =>
-	moize(
-		async (unit: string, token?: string): Promise<SurveyUnitData> => {
-			const { data, stateData, personalization } =
-				await authenticatedGetRequest<SurveyUnitData>(
-					surveyUnit(BASE_URL, unit),
-					token
-				);
+export const getSurveyUnitData =
+	(BASE_URL: string) =>
+	async (unit: string, token?: string): Promise<SurveyUnitData> => {
+		const { data, stateData, personalization } =
+			await authenticatedGetRequest<SurveyUnitData>(
+				surveyUnit(BASE_URL, unit),
+				token
+			);
 
-			return { data, stateData, personalization };
-		},
-		{ isPromise: true }
-	);
+		return { data, stateData, personalization };
+	};

--- a/src/lib/surveys/surveysApi.ts
+++ b/src/lib/surveys/surveysApi.ts
@@ -11,7 +11,7 @@ import { getMetadataSurvey } from './getMetadataSurvey';
 import { getNomenclature } from './getNomenclature';
 import { getRequiredNomenclatures } from './getRequiredNomenclatures';
 import { getSurvey } from './getSurvey';
-import { getSurveyUnitData } from './getSurveyUnit';
+import { fectchSurveyUnitData, getSurveyUnitData } from './getSurveyUnit';
 import { putSurveyUnitData } from './putSurveyUnitData';
 import { putSurveyUnitStateData } from './putSurveyUnitStateData';
 
@@ -23,6 +23,10 @@ export interface SurveyApi {
 		token: string | undefined
 	) => Promise<LunaticSource>;
 	getSurveyUnitData: (
+		unit: string,
+		token: string | undefined
+	) => Promise<SurveyUnitData>;
+	getFreshSurveyUnitData: (
 		unit: string,
 		token: string | undefined
 	) => Promise<SurveyUnitData>;
@@ -55,6 +59,7 @@ export const surveyApi: SurveyApi = {
 	getSurvey: getSurvey(DOMAIN),
 	getMetadataSurvey: getMetadataSurvey(DOMAIN),
 	getSurveyUnitData: getSurveyUnitData(DOMAIN),
+	getFreshSurveyUnitData: fectchSurveyUnitData(DOMAIN),
 	getRequiredNomenclatures: getRequiredNomenclatures(DOMAIN),
 	getNomenclature: getNomenclature(DOMAIN),
 	putSurveyUnitData: putSurveyUnitData(DOMAIN),

--- a/src/pages/portail/RoutingPortail.tsx
+++ b/src/pages/portail/RoutingPortail.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { AuthTypeEnum, environment } from '../../utils/read-env-vars';
 
 const { DEFAULT_SURVEY, AUTH_TYPE, VISUALIZE_ENABLED } = environment;
-const visualizeRoutingEnabled =
+export const visualizeRoutingEnabled =
 	AUTH_TYPE === AuthTypeEnum.None && VISUALIZE_ENABLED;
 
 export function RoutingPortail() {


### PR DESCRIPTION
moize permet d'éviter l'appel systématique au web service de getSurveyUnitData. DraftBanner l'invoque à chaque modification pour obtenir une clef de personnalization. Il a fallu donc introduire un paramètre demandant explicitement le rafraichissement sur la dernière page pour afficher la date correcte de validation.
A cause de visualize et de l'absence de get atomique sur l'API, une gestion spécifique de l'appel sur la page est impossible.
Une autre solution aurait été d'avoir un state global (redeux)