### PR TITLE
chore: remove unused positioning table property

### DIFF
--- a/src/typeLunatic/type-source.ts
+++ b/src/typeLunatic/type-source.ts
@@ -170,7 +170,6 @@ export type ComponentRosterForLoopType = {
 		rowspan?: number;
 		id?: string;
 	}[];
-	positioning: 'HORIZONTAL';
 };
 
 export type ComponentLoopType = {
@@ -189,7 +188,6 @@ export type ComponentTableType = {
 	lines: ComponentRosterForLoopType['lines'];
 	header: ComponentRosterForLoopType['header'];
 	body: ComponentRosterForLoopType['body'];
-	positioning: ComponentRosterForLoopType['positioning'];
 };
 
 export type ComponentNumberType = {


### PR DESCRIPTION
## Summary

The `"positioning"` property in table objects is unused.

## Done

Searched the whole project, only some occurrences of this in the type-source.ts