### PR TITLE
Suppression requêtes après validation qui s'affiche en erreur

### DIFF
--- a/src/components/orchestrator/UseLunatic.tsx
+++ b/src/components/orchestrator/UseLunatic.tsx
@@ -132,9 +132,7 @@ export function UseLunatic(props: PropsWithChildren<OrchestratorProps>) {
 		previousPageTag !== pageTag;
 
 	const handleGoNext = useCallback(() => {
-		if (isLastPage) {
-			saveChange({ pageTag, getData });
-		} else {
+		if (!isLastPage) {
 			shouldSync.current = true;
 			goNextPage?.();
 		}

--- a/src/components/orchestrator/UseLunatic.tsx
+++ b/src/components/orchestrator/UseLunatic.tsx
@@ -136,7 +136,7 @@ export function UseLunatic(props: PropsWithChildren<OrchestratorProps>) {
 			shouldSync.current = true;
 			goNextPage?.();
 		}
-	}, [goNextPage, isLastPage, saveChange, pageTag, getData]);
+	}, [goNextPage, isLastPage]);
 
 	const handleGoBack = useCallback(() => {
 		shouldSync.current = true;


### PR DESCRIPTION
Lorsqu'on valide, une requête s'envoie entre le retour de la requête de validation et le traitement qui suit (redirection page d'accueil). 
Cette requête (un PUT /state-data) ne sert à rien dans notre cas, il n'y a pas de données, et firefox l'interromp pour faire la redirection vers la page d'accueil. 
Cette interruption s'affiche rapidement en tant qu'erreur d'enregistrement serveur dans l'ihm. 
On préfère supprimer tout enregistrement sur la dernière page pour éviter cette mauvais UX