### PR TITLE
prevent display error saving before last page

### DIFF
--- a/src/components/navigation/Continuer.tsx
+++ b/src/components/navigation/Continuer.tsx
@@ -3,9 +3,7 @@ import { Button } from '@codegouvfr/react-dsfr/Button';
 import { useNavigate } from 'react-router';
 import { isComponentsContainSequence } from '../../lib/commons/isComponentscontainSequence';
 import { ComponentType } from '../../typeLunatic/type-source';
-import { CollectStatusEnum, OrchestratedElement } from '../../typeStromae/type';
-import { uri404 } from '../../lib/domainUri';
-import { useSaveSurveyUnitStateData } from '../../hooks/useSaveSurveyUnitData';
+import { OrchestratedElement } from '../../typeStromae/type';
 
 function getButtonTitle(getComponents: () => Array<ComponentType>) {
 	if (getComponents) {
@@ -48,45 +46,48 @@ function getStatus(
 export function Continuer(props: OrchestratedElement) {
 	const [saving, setSaving] = useState(false);
 	const {
-		goNextPage = () => null,
+		goNextPage = async () => null,
 		isLastPage,
 		getComponents = () => [],
 		// `waiting` is activated to communicate to users that an API request is in process
 		waiting = false,
-		pageTag,
 	} = props;
 	const navigate = useNavigate();
-	const saveSuData = useSaveSurveyUnitStateData();
 	const buttonContent =
 		waiting || saving
 			? `Chargement`
 			: getStatus(getComponents, isLastPage ?? false, saving);
 
 	const handleClick = useCallback(
-		(event: React.MouseEvent) => {
+		async (event: React.MouseEvent) => {
 			event.preventDefault();
 
-			if (isLastPage) {
-				setSaving(true);
-				saveSuData({
-					pageTag,
-					collectStatus: CollectStatusEnum.Validated,
-				})
-					.then(() => {
-						navigate(0);
-						setSaving(false);
-					})
-					.catch(() => {
-						navigate(uri404());
-						setSaving(false);
-					});
-			}
-
+			// if (isLastPage) {
+			// 	setSaving(true);
+			// 	saveSuData({
+			// 		pageTag,
+			// 		collectStatus: CollectStatusEnum.Validated,
+			// 	})
+			// 		.then(() => {
+			// 			navigate(0);
+			// 			setSaving(false);
+			// 		})
+			// 		.catch(() => {
+			// 			navigate(uri404());
+			// 			setSaving(false);
+			// 		});
+			// } else {
 			window.scrollTo(0, 0);
 			document.getElementById('button-precedent')?.focus();
-			goNextPage();
+			setSaving(true);
+			await goNextPage();
+			setSaving(false);
+			if (isLastPage) {
+				navigate(0);
+			}
+			// }
 		},
-		[goNextPage, isLastPage, navigate, saveSuData, pageTag]
+		[goNextPage, isLastPage, navigate]
 	);
 
 	return (

--- a/src/components/orchestrator/UseLunatic.tsx
+++ b/src/components/orchestrator/UseLunatic.tsx
@@ -131,9 +131,9 @@ export function UseLunatic(props: PropsWithChildren<OrchestratorProps>) {
 		previousPageTag !== undefined &&
 		previousPageTag !== pageTag;
 
-	const handleGoNext = useCallback(() => {
+	const handleGoNext = useCallback(async () => {
 		if (isLastPage) {
-			saveChange({ pageTag, getData });
+			await saveChange({ pageTag, getData, isLastPage });
 		} else {
 			shouldSync.current = true;
 			goNextPage?.();

--- a/src/components/orchestrator/useSaving/useSaving.ts
+++ b/src/components/orchestrator/useSaving/useSaving.ts
@@ -3,7 +3,14 @@ import { CollectStatusEnum, SavingFailure } from '../../../typeStromae/type';
 import { loadSourceDataContext } from '../../loadSourceData/LoadSourceDataContext';
 import { useSaveSurveyUnitStateData } from '../../../hooks/useSaveSurveyUnitData';
 
-function getCollectStatus(changing: boolean, previous: CollectStatusEnum) {
+function getCollectStatus(
+	changing: boolean,
+	previous: CollectStatusEnum,
+	isLastPage?: boolean
+) {
+	if (isLastPage) {
+		return CollectStatusEnum.Validated;
+	}
 	if (previous === CollectStatusEnum.Validated) {
 		return CollectStatusEnum.Validated;
 	}
@@ -34,9 +41,18 @@ export function useSaving({
 	}, []);
 
 	const saveChange = useCallback(
-		async ({ pageTag, getData }: { pageTag: string; getData: () => any }) => {
+		async ({
+			pageTag,
+			getData,
+			isLastPage,
+		}: {
+			pageTag: string;
+			getData: () => any;
+			isLastPage?: boolean;
+		}) => {
 			setFailure(undefined);
 			setWaiting(true);
+
 			try {
 				// save data
 				const isOnChange = changes.current.size !== 0;
@@ -58,7 +74,11 @@ export function useSaving({
 				// save stateData
 				const state = await saveSuData({
 					pageTag,
-					collectStatus: getCollectStatus(isOnChange, currentStatus),
+					collectStatus: getCollectStatus(
+						isOnChange,
+						currentStatus,
+						isLastPage
+					),
 				});
 				setCurrentStatus(state.state);
 				setWaiting(false);
@@ -67,7 +87,7 @@ export function useSaving({
 				setWaiting(false);
 			}
 		},
-		[currentStatus, putSurveyUnitData, setFailure, setWaiting, saveSuData]
+		[setFailure, setWaiting, saveSuData, currentStatus, putSurveyUnitData]
 	);
 
 	return { listenChange, saveChange };


### PR DESCRIPTION
pour éviter d'afficher un message d'erreur en interrompant une requête inutile, j'ai supprimé la requête saveSuData du bouton continuer et me suis assuré que la fonction goNextPage qui lui est transmis déduise correctement l'état du questionnaire sur la dernière page